### PR TITLE
[DE-467] Configuración para assets

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,6 +55,7 @@ module.exports = function (env) {
         env.NODE_ENV === "production"
           ? "static/[name].[contenthash].js"
           : "index.js",
+      assetModuleFilename: "static/media/[hash][ext][query]",
       path: path.resolve(__dirname, "build"),
       publicPath: "",
       clean: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,8 +32,14 @@ const rulesStyles = {
     MiniCssExtractPlugin.loader,
     // Creates `style` nodes from JS strings
     "css-loader",
-    // Compiles Sass to CSS
-    "sass-loader",
+    {
+      loader: "sass-loader",
+      options: {
+        sassOptions: {
+          includePaths: [path.resolve(__dirname, "./src/assets/scss")],
+        },
+      },
+    },
   ],
 };
 


### PR DESCRIPTION
<s>Implementar `node-sass-glob-importer` en la configuración de webpack</s>
Se propone usar la forma de importar los archivos en las hojas de estilo como lo indica la documentación de [SASS](https://sass-lang.com/documentation/at-rules/use) con esto es innecesario el uso del plugin `node-sass-glob-importer` y de `node-sass DEPRECATED`

_**nota 1:**_ Luego de hacer una prueba de concepto usando [_@use_](https://sass-lang.com/documentation/at-rules/use) de _SASS_ se agregó en webpack la configuración de un alias para usar rutas relativas en los imports 👇 
`includePaths: [path.resolve(__dirname, "./src/assets/scss")],`

_**nota 2:**_ También se agregó una configuración para ubicar los _assets_ usados en la carpeta _/static/media_

[DE-467](https://makingsense.atlassian.net/browse/DE-467)