### PR TITLE
feat: add visibility hidden in overlay

### DIFF
--- a/src/assets/scss/helpers/_classes.scss
+++ b/src/assets/scss/helpers/_classes.scss
@@ -6,10 +6,12 @@
 .dp-library {
   .dp-hidden-page {
     opacity: 0;
+    visibility: hidden;
 
     &.dp-show-page {
       opacity: 1;
-      transition: all 0.4s ease-in-out;
+      visibility: visible;
+      transition: all 0.5s ease-in-out;
     }
   }
 }


### PR DESCRIPTION
Visibility hidden was added to the container so that the user cannot have action on the fields until the page is rendered

![bug-overlay](https://user-images.githubusercontent.com/46735526/170130411-6db656c7-f8c1-4807-a245-ae5854482c94.gif)

