### PR TITLE
fix: deprecation using / for division outside of calc

### DIFF
--- a/src/assets/scss/modules/_grid-system.scss
+++ b/src/assets/scss/modules/_grid-system.scss
@@ -4,7 +4,7 @@
 
 .dp-library {
   @function columns($columns, $total-columns) {
-    @return percentage($columns / $total-columns);
+    @return percentage(calc($columns / $total-columns));
   }
 
   @media screen and (min-width: 320px) {


### PR DESCRIPTION
Deprecation Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.  

![fix-compilation](https://user-images.githubusercontent.com/46735526/182235091-d20e9615-30e3-4709-9a86-88764a475e72.gif)

