### PR TITLE
fix: add max width in component tooltip block

### DIFF
--- a/src/assets/scss/modules/_tooltip.scss
+++ b/src/assets/scss/modules/_tooltip.scss
@@ -230,6 +230,7 @@
     color: colors.$dp-color-darkgrey;
     width: max-content;
     min-width: 150px;
+    max-width: 240px;
     display: flex;
     flex-direction: column;
     justify-content: center;


### PR DESCRIPTION
![thumbnail-retoque-tooltip](https://user-images.githubusercontent.com/46735526/184430229-f0569603-9f0a-4444-81c3-f806e66cdc7a.jpg)
