### PR TITLE
[DE-719] Estilos dropdown - web component

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "html-webpack-plugin": "5.5.0",
     "jquery": "3.6.0",
     "lit-html": "2.3.0",
-    "lit": "^2.2.8",
     "loader": "2.1.1",
     "mini-css-extract-plugin": "2.6.1",
     "prettier": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "html-webpack-plugin": "5.5.0",
     "jquery": "3.6.0",
     "lit-html": "2.3.0",
+    "lit": "^2.2.8",
     "loader": "2.1.1",
     "mini-css-extract-plugin": "2.6.1",
     "prettier": "2.7.1",

--- a/src/assets/scss/components/button.scss
+++ b/src/assets/scss/components/button.scss
@@ -1,0 +1,49 @@
+@use "core/variables";
+@use "core/settings";
+@use "helpers/colors";
+@use "helpers/mixins";
+@use "modules/preload";
+
+// mixin equal to .dp-button, all button can extend this
+@mixin library-button {
+  display: inline-block;
+  text-align: center;
+  text-decoration: none;
+  border: none;
+  appearance: none;
+  font-family: settings.$dp-font-family-proximanova;
+  border-radius: variables.$dp-border-radius;
+  font-weight: settings.$dp-font-weight-bold;
+  letter-spacing: 0.6px;
+  @include mixins.transition-all;
+
+  &:disabled {
+    pointer-events: none;
+    opacity: 0.4;
+  }
+}
+
+// .dp-button-exit can extend this mixin
+@mixin grey-button {
+  @include library-button;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-left: 2px;
+  color: colors.$dp-color-grey;
+  height: 34px;
+  position: relative;
+  right: 3px;
+  top: 0;
+  &:hover,
+  &:active {
+    background: colors.$dp-color-white;
+  }
+
+  &:focus,
+  &.active {
+    box-shadow: inset 0 0 0 2px colors.$dp-color-orange-focus,
+      inset 0 0 0 3px colors.$dp-color-white;
+    background: colors.$dp-color-white;
+  }
+}

--- a/src/assets/scss/components/dropdown.scss
+++ b/src/assets/scss/components/dropdown.scss
@@ -1,0 +1,79 @@
+@use "button";
+@use "core/variables";
+@use "helpers/colors";
+
+@mixin scrollbar {
+  margin: variables.$dp-spaces--lv0;
+  padding: variables.$dp-spaces--lv0;
+  overflow: auto;
+  width: 200px;
+  height: 150px;
+
+  /* Tamaño del scroll */
+  &::-webkit-scrollbar {
+    width: 4px;
+    scrollbar-width: 4px;
+  }
+
+  /* barra thumb de scroll */
+  &::-webkit-scrollbar-thumb {
+    background: colors.$dp-color-silver;
+    border-radius: 4px;
+    right: 10px;
+  }
+
+  &::-webkit-scrollbar-thumb:active {
+    background-color: colors.$dp-color-lightgrey;
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: colors.$dp-color-silver;
+    box-shadow: 0 0 2px 1px rgba(0, 0, 0, 0.2);
+  }
+
+  /* track de scroll */
+  &::-webkit-scrollbar-track {
+    background: colors.$dp-color-snow;
+    border-radius: 4px;
+  }
+
+  &::-webkit-scrollbar-track:hover,
+  &::-webkit-scrollbar-track:active {
+    background: colors.$dp-color-snow;
+  }
+}
+
+dp-dropdown {
+  display: flex;
+  justify-content: flex-end;
+  position: relative;
+
+  dp-dropbdown-button > * {
+    @include button.grey-button;
+    border: 1px solid colors.$dp-border-grey;
+    font-size: variables.$dp-sizing--lvl4;
+    background-color: colors.$dp-color-snow;
+    font-weight: 800;
+    width: 42px;
+  }
+
+  dp-dropdown-content {
+    position: absolute;
+    display: none;
+    top: 40px;
+    text-align: left;
+    line-height: variables.$dp-spaces--lv4;
+    overflow: hidden;
+    right: 0;
+    outline: 0;
+    padding: 5px;
+    border-radius: 5px;
+    background-color: colors.$dp-color-white;
+    box-shadow: inset 0 0 0 3px colors.$dp-color-snow,
+      inset 0 0 0 5px colors.$dp-color-orange-focus;
+    z-index: 3;
+    dp-dropdown-scroll {
+      @include scrollbar;
+    }
+  }
+}

--- a/src/assets/scss/styles.scss
+++ b/src/assets/scss/styles.scss
@@ -29,3 +29,4 @@
 @use "modules";
 @use "utilities";
 @use "templates";
+@use "components/dropdown";

--- a/src/components/Dropdown.js
+++ b/src/components/Dropdown.js
@@ -1,0 +1,38 @@
+import { css, html, LitElement } from "lit";
+
+export class Dropdown extends LitElement {
+  static properties = {
+    open: { state: true },
+  };
+
+  static get styles() {
+    return css`
+      .wrapper {
+        width: fit-content;
+      }
+    `;
+  }
+
+  openCloseMenuHandler = () => (this.open = !this.open);
+
+  leaveMenuHandler = () => (this.open = false);
+
+  render() {
+    return html`
+      <div class="wrapper" @mouseleave="${this.leaveMenuHandler}">
+        <button @click="${this.openCloseMenuHandler}">
+          Click para mostrar el menu
+        </button>
+        ${this.open
+          ? html` <ul>
+              <li>Hola soy un li</li>
+              <li>Hola soy un li</li>
+              <li>Hola soy un li</li>
+              <li>Hola soy un li</li>
+              <li>Hola soy un li</li>
+            </ul>`
+          : ""}
+      </div>
+    `;
+  }
+}

--- a/src/components/Dropdown.js
+++ b/src/components/Dropdown.js
@@ -1,30 +1,53 @@
-import { css, html, LitElement } from "lit";
+export class Dropdown extends HTMLElement {
+  _open = false;
+  _button;
+  _expandableBox;
 
-export class Dropdown extends LitElement {
-  static properties = {
-    open: { state: true },
+  openCloseMenuHandler = () => {
+    this._open = !this._open;
+    this.updateRender();
   };
 
-  static get styles() {
-    return css`
-      .wrapper {
-        width: fit-content;
-      }
-    `;
+  constructor() {
+    super();
+    this._button = this.querySelector("dp-dropdown>dp-dropbdown-button");
+    this._expandableBox = this.querySelector("dp-dropdown>dp-dropdown-content");
+
+    //TODO: use class for hide or show expandableBox
+    this._expandableBox.setAttribute(
+      "style",
+      `display: ${this._open ? "block" : "none"}`
+    );
+
+    this.append(this._button, this._expandableBox);
   }
 
-  openCloseMenuHandler = () => (this.open = !this.open);
+  updateRender() {
+    //TODO: use class for hide or show expandableBox
+    this._expandableBox.setAttribute(
+      "style",
+      `display: ${this._open ? "block" : "none"}`
+    );
+  }
 
-  leaveMenuHandler = () => (this.open = false);
+  collapse() {
+    this._open = false;
+    this.updateRender();
+  }
 
-  render() {
-    return html`
-      <div class="wrapper" @mouseleave="${this.leaveMenuHandler}">
-        <button @click="${this.openCloseMenuHandler}">
-          Click para mostrar el menu
-        </button>
-        ${this.open ? html`<slot></slot>` : ""}
-      </div>
-    `;
+  _collapseOther() {
+    const all = document.querySelectorAll("dp-dropdown");
+    all.forEach((dropdown) => {
+      if (dropdown !== this) {
+        dropdown.collapse();
+      }
+    });
+  }
+
+  connectedCallback() {
+    this._button.addEventListener("click", () => {
+      this.openCloseMenuHandler();
+      this._collapseOther();
+    });
   }
 }

--- a/src/components/Dropdown.js
+++ b/src/components/Dropdown.js
@@ -23,15 +23,7 @@ export class Dropdown extends LitElement {
         <button @click="${this.openCloseMenuHandler}">
           Click para mostrar el menu
         </button>
-        ${this.open
-          ? html` <ul>
-              <li>Hola soy un li</li>
-              <li>Hola soy un li</li>
-              <li>Hola soy un li</li>
-              <li>Hola soy un li</li>
-              <li>Hola soy un li</li>
-            </ul>`
-          : ""}
+        ${this.open ? html`<slot></slot>` : ""}
       </div>
     `;
   }

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,0 +1,5 @@
+import { Dropdown } from "./Dropdown";
+
+export const registerComponents = () => {
+  customElements.define("dp-dropdown", Dropdown);
+};

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -3,3 +3,24 @@ import { Dropdown } from "./Dropdown";
 export const registerComponents = () => {
   customElements.define("dp-dropdown", Dropdown);
 };
+
+/**
+ * Globals behaviors over document click event
+ */
+export const globalBehaviors = () => {
+  document.addEventListener("click", (event) => {
+    const tagNamesPath = event
+      .composedPath()
+      .map((e) => e.tagName?.toLowerCase());
+
+    if (!tagNamesPath.includes("dp-dropdown")) {
+      const all = document.querySelectorAll("dp-dropdown");
+      all.forEach((element) => element.collapse());
+    }
+
+    // Consider the next block for new global behaviors. Eg.
+    // if (!tagNamesPath.includes("my-custom-element")) {
+    //   ...my global logic
+    // }
+  });
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,9 @@
 import "./index.scss";
 import { initDopplerUI } from "./js";
-import { registerComponents } from "./components";
+import { registerComponents, globalBehaviors } from "./components";
 
 if (window["style-guide-configuration"]?.autoInitialize) {
   initDopplerUI();
   registerComponents();
+  globalBehaviors();
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 import "./index.scss";
 import { initDopplerUI } from "./js";
+import { registerComponents } from "./components";
 
 if (window["style-guide-configuration"]?.autoInitialize) {
   initDopplerUI();
+  registerComponents();
 }

--- a/src/stories/Dropdown.stories.js
+++ b/src/stories/Dropdown.stories.js
@@ -1,12 +1,21 @@
 import { html } from "lit";
 
 export const Default = () => {
-  return html`<dp-dropdown>
-    <div>Option 1</div>
-    <div>Option 2</div>
-    <div>Option 3</div>
-    <div>Option 4</div>
-  </dp-dropdown>`;
+  return html`
+    <dp-dropdown>
+      <dp-dropbdown-button>
+        <button>Click me!!</button>
+      </dp-dropbdown-button>
+      <dp-dropdown-content>
+        <a>Nombre</a>
+        <a>Apellido</a>
+        <a>Cumpleaños</a>
+        <a>Email</a>
+        <a>Nombre</a>
+        <a>Apellido</a>
+      </dp-dropdown-content>
+    </dp-dropdown>
+  `;
 };
 
 // More on default export:

--- a/src/stories/Dropdown.stories.js
+++ b/src/stories/Dropdown.stories.js
@@ -4,15 +4,17 @@ export const Default = () => {
   return html`
     <dp-dropdown>
       <dp-dropbdown-button>
-        <button>Click me!!</button>
+        <button><i class="ms-icon icon-brackets"></i></button>
       </dp-dropbdown-button>
       <dp-dropdown-content>
-        <a>Nombre</a>
-        <a>Apellido</a>
-        <a>Cumpleaños</a>
-        <a>Email</a>
-        <a>Nombre</a>
-        <a>Apellido</a>
+        <dp-dropdown-scroll style="display: flex; flex-direction: column">
+          <a>Nombre</a>
+          <a>Apellido</a>
+          <a>Cumpleaños</a>
+          <a>Email</a>
+          <a>Nombre</a>
+          <a>Apellido</a>
+        </dp-dropdown-scroll>
       </dp-dropdown-content>
     </dp-dropdown>
   `;

--- a/src/stories/Dropdown.stories.js
+++ b/src/stories/Dropdown.stories.js
@@ -1,0 +1,15 @@
+import { html } from "lit";
+
+export const Default = () => {
+  return html` <dp-dropdown></dp-dropdown>`;
+};
+
+// More on default export:
+// https://storybook.js.org/docs/web-components/writing-stories/introduction#default-export
+export default {
+  title: "Components/Dropdown",
+  // More on argTypes: https://storybook.js.org/docs/web-components/api/argtypes
+  argTypes: {},
+};
+
+const Template = (args) => Default(args);

--- a/src/stories/Dropdown.stories.js
+++ b/src/stories/Dropdown.stories.js
@@ -1,7 +1,12 @@
 import { html } from "lit";
 
 export const Default = () => {
-  return html` <dp-dropdown></dp-dropdown>`;
+  return html`<dp-dropdown>
+    <div>Option 1</div>
+    <div>Option 2</div>
+    <div>Option 3</div>
+    <div>Option 4</div>
+  </dp-dropdown>`;
 };
 
 // More on default export:

--- a/src/stories/Dropdown.stories.js
+++ b/src/stories/Dropdown.stories.js
@@ -1,4 +1,4 @@
-import { html } from "lit";
+import { html } from "lit-html";
 
 export const Default = () => {
   return html`


### PR DESCRIPTION
Revisando los estilos del dropdown noté que la creación de los web component pueden ser una oportunidad para limpiar los estilos que tenemos repetidos en el CSS de style-guide.

El siguiente código lo convertí en mixin porque puede ser reusable en otros tipos de listas.
![image](https://user-images.githubusercontent.com/6733401/184465267-ba8b471b-e1f0-46ee-8cf4-352dadd2a4bb.png)

Lo mismo sucede con .dp-button y algunas de sus implementaciones.