### PR TITLE
fix: support "show after load" mechanism without dp-library container

### DIFF
--- a/src/assets/scss/helpers/_classes.scss
+++ b/src/assets/scss/helpers/_classes.scss
@@ -3,12 +3,10 @@
 /// @group Classes
 ///
 
-.dp-library {
-  .dp-hidden-page {
-    &.dp-show-page {
-      opacity: 1;
-      visibility: visible;
-      transition: all 0.5s ease-in-out;
-    }
+.dp-hidden-page {
+  &.dp-show-page {
+    opacity: 1;
+    visibility: visible;
+    transition: all 0.5s ease-in-out;
   }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1157864/186216240-c8d96375-2597-4fd0-877e-6cbee6f5d267.png)

I need to use this mechanism without adding the `dp-library` class to the whole page.

I think that it will work without issues.

Thoughts? 