### PR TITLE
[DE-808] Using region role in saving animation

### DIFF
--- a/src/assets/scss/helpers/_animations.scss
+++ b/src/assets/scss/helpers/_animations.scss
@@ -126,33 +126,41 @@
       transform: rotate(-359deg);
     }
   }
+}
 
-  @keyframes pulse-animation {
-    0% {
-      transform: scale(0.45);
-      box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.7);
-    }
-
-    70% {
-      transform: scale(1);
-      box-shadow: 0 0 0 10px rgba(0, 0, 0, 0.5);
-    }
-
-    100% {
-      transform: scale(0.95);
-      box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
-    }
+@keyframes pulse-animation {
+  0% {
+    transform: scale(0.45);
+    box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.7);
   }
 
-  .pulse {
-    background: rgba(0, 0, 0, 0.8);
-    border-radius: 50%;
-    box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.5);
-    margin: 10px;
-    height: 20px;
-    width: 20px;
+  70% {
     transform: scale(1);
-    animation: pulse-animation 1s infinite;
+    box-shadow: 0 0 0 10px rgba(0, 0, 0, 0.5);
+  }
+
+  100% {
+    transform: scale(0.95);
+    box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
+  }
+}
+
+.dp-animate {
+  &--saving {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+
+    .pulse {
+      background: rgba(0, 0, 0, 0.8);
+      border-radius: 50%;
+      box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.5);
+      margin: 10px;
+      height: 20px;
+      width: 20px;
+      transform: scale(1);
+      animation: pulse-animation 1s infinite;
+    }
   }
 }
 

--- a/src/stories/Animations.js
+++ b/src/stories/Animations.js
@@ -3,6 +3,9 @@ import { html } from "lit-html";
 /**
  * Primary UI component for user interaction
  */
-export const Animations = ({ animationName }) => {
-  return html` <div class="${animationName}"></div> `;
+export const Animations = ({ label }) => {
+  return html`<div class="dp-animate--saving">
+    <span>${label}</span>
+    <div class="pulse"></div>
+  </div>`;
 };

--- a/src/stories/Animations.stories.js
+++ b/src/stories/Animations.stories.js
@@ -1,21 +1,16 @@
-import { Animations } from "./Animations";
+import { Animations } from "./Animations.js";
 
 // More on default export:
 // https://storybook.js.org/docs/web-components/writing-stories/introduction#default-export
 export default {
   title: "Components/Animations",
   // More on argTypes: https://storybook.js.org/docs/web-components/api/argtypes
-  argTypes: {
-    animationName: {
-      control: { type: "select" },
-      defaultValue: "pulse",
-      options: ["pulse"],
-    },
-  },
+  argTypes: {},
 };
 
 // More on component templates:
 // https://storybook.js.org/docs/web-components/writing-stories/introduction#using-args
 const Template = (args) => Animations(args);
 
-export const Default = Template.bind({});
+export const Saving = Template.bind();
+Saving.args = { label: "Saving" };


### PR DESCRIPTION
Rename saving label.

<s>Refactor using [ARIA Live Regions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions), the priority aria live is **_polite_**

> **aria-live:** The aria-live=_POLITENESS_SETTING_ is used to set the priority with which screen reader should treat updates to live regions - the possible settings are: off, polite or assertive. The default setting is off. This attribute is by far the most important.
</s>WON'T FIX


**_Issue related:_** [PR-431](https://github.com/FromDoppler/doppler-editors-webapp/pull/431)