### PR TITLE
Dat 1428 changes styles in purchase summary section

### DIFF
--- a/src/assets/scss/templates/_payment-process.scss
+++ b/src/assets/scss/templates/_payment-process.scss
@@ -492,10 +492,10 @@
       }
 
       .dp-taxes-excluded {
-        font-size: variables.$dp-sizing--lvl1;
+        font-size: variables.$dp-sizing--lvl2;
         font-weight: normal;
         line-height: 15px;
-        margin-top: variables.$dp-spaces--lv4;
+        margin-top: variables.$dp-spaces--lv1;
         color: colors.$dp-color-grey;
       }
 

--- a/src/assets/scss/templates/_payment-process.scss
+++ b/src/assets/scss/templates/_payment-process.scss
@@ -497,6 +497,7 @@
         line-height: 15px;
         margin-top: variables.$dp-spaces--lv1;
         color: colors.$dp-color-grey;
+        justify-content: end;
       }
 
       .dp-money {

--- a/src/assets/scss/templates/_payment-process.scss
+++ b/src/assets/scss/templates/_payment-process.scss
@@ -513,6 +513,11 @@
       button[aria-label="secure payment"] {
         font-weight: normal;
         padding-left: variables.$dp-sizing--lvl0;
+        color: colors.$dp-color-darkgrey;
+        display: flex;
+        .dpicon {
+          margin-right: variables.$dp-spaces--lv1;
+        }
       }
     }
   }

--- a/src/documentation/templates/payment-process.html
+++ b/src/documentation/templates/payment-process.html
@@ -1179,11 +1179,8 @@
                   <span>TOTAL:</span>
                   <span> <span class="dp-money">US$</span>42,75</span>
                 </li>
-                <li>
-                  <span></span>
-                  <span class="dp-taxes-excluded">
-                    (Impuestos no incluídos)
-                  </span>
+                <li class="dp-taxes-excluded">
+                  <span> (Impuestos no incluídos) </span>
                 </li>
                 <li class="m-t-18">
                   <button

--- a/src/documentation/templates/payment-process.html
+++ b/src/documentation/templates/payment-process.html
@@ -1179,6 +1179,12 @@
                   <span>TOTAL:</span>
                   <span> <span class="dp-money">US$</span>42,75</span>
                 </li>
+                <li>
+                  <span></span>
+                  <span class="dp-taxes-excluded">
+                    (Impuestos no incluídos)
+                  </span>
+                </li>
                 <li class="m-t-18">
                   <button
                     type="button"


### PR DESCRIPTION
### **Changes in Purchase Summary Section**
**Jira Ticket:** https://makingsense.atlassian.net/browse/DAT-1428

**Before:**
<img width="375" alt="Captura de Pantalla 2023-04-05 a la(s) 8 29 21 a  m" src="https://user-images.githubusercontent.com/84402180/230095247-20685423-eb55-4681-9a31-b0157dfb236e.png">


**After:**
<img width="371" alt="Captura de Pantalla 2023-04-05 a la(s) 8 27 27 a  m" src="https://user-images.githubusercontent.com/84402180/230094743-145e8fa9-b7f4-458b-a6cb-5c7c0bee4797.png">
