### PR TITLE
feat: create storybook template for user account header and messages

### DIFF
--- a/src/assets/scss/core/_typography.scss
+++ b/src/assets/scss/core/_typography.scss
@@ -16,6 +16,7 @@ $dp-fontsize-awa: 1rem; /*16px*/
 $dp-fontfamily-awa: "proxima-nova", Helvetica, Arial, sans-serif;
 $dp-fontlineheight-awa: 1.5rem; /*24px*/
 $dp-fontsize-base: 1rem; /*16px*/
+$dp-fontsize-small: 0.9rem; /*14px*/
 $dp-linheight-text-validations: 0.9rem; /*14px*/
 $dp-linheight-small: 0.75rem; /*12px*/
 $dp-label-fontsize-base: 0.9rem; /*14px*/

--- a/src/assets/scss/helpers/_colors.scss
+++ b/src/assets/scss/helpers/_colors.scss
@@ -5,6 +5,7 @@
 
 $dp-color-focus-checkbox: #ffdc95;
 $dp-color-text-label: #212121;
+$dp-color-text: #212121;
 $dp-color-text-input: #838370;
 $dp-color-default-checkbox: #838370;
 $dp-color-assistive-text: #838370;

--- a/src/assets/scss/templates/_header.scss
+++ b/src/assets/scss/templates/_header.scss
@@ -10,11 +10,13 @@
 @use "core/settings";
 @use "utilities/ellipsis";
 @use "modules/breakpoints";
+@use "core/typography";
 
 .dp-library {
   .header-main {
     border-bottom: 1px solid colors.$dp-color-silver;
-    box-shadow: 0 0 0 4px colors.$dp-color-snow;
+    box-shadow: 3px 13px 17px -19px rgba(0, 0, 0, 0.45),
+      0px 25px 20px -20px rgba(0, 0, 0, -0.55);
     background: colors.$dp-color-white;
     position: relative;
     width: 100%;
@@ -23,7 +25,7 @@
     z-index: settings.$header-main-overlay;
     display: flex;
     line-height: 1.2;
-    font-family: settings.$dp-font-family;
+    font-family: typography.$dp-fontfamily-awa;
     height: auto;
     min-height: 70px;
     flex-direction: column;
@@ -51,8 +53,7 @@
 
   .dp-header--cm {
     .dp-logo--cm {
-      margin: var.$dp-spaces--lv3 var.$dp-spaces--lv0 var.$dp-spaces--lv1
-        var.$dp-spaces--lv5;
+      margin: var.$dp-spaces--lv3 var.$dp-spaces--lv3 var.$dp-spaces--lv0;
       width: 280px;
       height: 50px;
       display: block;
@@ -75,6 +76,11 @@
       flex: 1;
       margin-left: 0;
     }
+    .sub-menu {
+      a.active {
+        padding-bottom: 17px;
+      }
+    }
   }
 
   .dp-logo--cm {
@@ -82,8 +88,8 @@
   }
 
   .header-wrapper {
-    padding-left: 2%;
-    padding-right: 2%;
+    padding-left: var.$dp-spaces--lv3;
+    padding-right: var.$dp-spaces--lv3;
     height: 70px;
     justify-content: space-between;
     align-items: center;
@@ -93,6 +99,7 @@
   .logo {
     display: flex;
     width: 40px;
+    margin-right: var.$dp-spaces--lv6;
   }
 
   .icon-doppler-logo {
@@ -105,7 +112,7 @@
 
   .nav-left-main {
     flex: 1;
-    margin-left: 20px;
+    margin-left: var.$dp-spaces--lv0;
   }
 
   .menu-main {
@@ -118,10 +125,11 @@
 
     a {
       text-decoration: none;
-      color: colors.$dp-color-grey;
-      text-transform: uppercase;
-      font-family: settings.$dp-font-family;
-      font-size: var.$dp-sizing--lvl2;
+      color: colors.$dp-color-text;
+      font-family: typography.$dp-fontfamily-awa;
+      line-height: typography.$dp-fontlineheight-awa;
+      font-size: typography.$dp-fontsize-base;
+      transition: all 0.1s ease-in-out;
     }
 
     a.active {
@@ -149,7 +157,7 @@
     }
 
     li {
-      margin-right: 25px;
+      margin-right: var.$dp-spaces--lv4;
       padding: 0 10px 0 0;
       line-height: 37px;
       white-space: nowrap;
@@ -157,17 +165,17 @@
 
     a {
       text-decoration: none;
-      color: colors.$dp-color-grey;
-      font-family: settings.$dp-font-family;
-      font-size: var.$dp-sizing--lvl2;
-      padding-bottom: 12px;
+      color: colors.$dp-color-text;
+      font-family: typography.$dp-fontfamily-awa;
+      font-size: typography.$dp-fontsize-small;
+      padding-bottom: var.$dp-spaces--lv2;
       text-transform: none;
     }
 
     a.active {
       border-bottom: 3px solid colors.$dp-color-yellow;
       font-weight: settings.$dp-font-weight-bold;
-      padding-bottom: 9px;
+      padding-bottom: 11px;
     }
   }
 
@@ -186,15 +194,19 @@
 
   .nav-right-main--list {
     list-style: none;
-    margin: 0;
+    margin: var.$dp-spaces--lv0;
     display: flex;
     align-items: stretch;
 
     & > li {
-      margin: 0 10px;
+      margin: var.$dp-spaces--lv0 var.$dp-spaces--lv2;
       position: relative;
       align-items: center;
       display: flex;
+    }
+
+    & > li:last-child {
+      margin: var.$dp-spaces--lv0 var.$dp-spaces--lv0;
     }
 
     a {

--- a/src/assets/scss/templates/_messages-header.scss
+++ b/src/assets/scss/templates/_messages-header.scss
@@ -17,6 +17,7 @@
     padding: variables.$dp-spaces--lv2;
     margin-bottom: variables.$dp-spaces--lv1;
     font-family: settings.$dp-font-family;
+    width: 100%;
   }
 
   .messages-container .wrapper {

--- a/src/documentation/templates/header-component.html
+++ b/src/documentation/templates/header-component.html
@@ -32,6 +32,7 @@
             <nav class="nav-left-main">
               <div class="menu-main--container">
                 <ul class="menu-main">
+                  <li><a href="#">Inicio</a></li>
                   <li class="submenu-item">
                     <a href="#" class="active">Campañas</a>
                     <ul class="sub-menu sub-campaings open">
@@ -56,6 +57,7 @@
                   <li><a href="#">Automation</a></li>
                   <li><a href="#">Reportes</a></li>
                   <li><a href="#">Plantillas</a></li>
+                  <li><a href="#">Integraciones</a></li>
                 </ul>
               </div>
               <!-- menu-main--container only-mobile -->

--- a/src/stories/Header.js
+++ b/src/stories/Header.js
@@ -1,0 +1,209 @@
+import { html } from "lit-html";
+
+/**
+ * Primary UI component for user interaction
+ */
+export const Header = ({
+  accountState,
+  hasDopplerLogo,
+  clientManagerContent,
+}) => {
+  let messages = null;
+  let content = null;
+  switch (accountState) {
+    case "warning":
+      messages = html`<div class="messages-container warning">
+        <div class="wrapper">
+          <p>
+            Thanks! We’ll contact you ASAP and if everything is fine, you’ll be
+            able to send your Campaign.
+          </p>
+          <a href="#" class="button button--light button--tiny">Upgrade Now</a>
+        </div>
+      </div>`;
+      break;
+    case "info":
+      messages = html`<div class="messages-container info">
+        <div class="wrapper">
+          <p>
+            Posees una cuenta gratis de 500 Suscriptores. Potencia tus Campañas
+            con los beneficios de un Plan Pago.
+          </p>
+          <a href="#" class="button button--light button--tiny"
+            >Comprar Ahora</a
+          >
+        </div>
+      </div>`;
+      break;
+    case "blocker":
+      messages = html`<div class="messages-container blocker">
+        <div class="wrapper">
+          <p>
+            Para que puedas enviar tu próxima Campaña, antes necesitamos
+            verificar el origen de tus Suscriptores.
+          </p>
+          <a href="#" class="button button--light button--tiny"
+            >Verificar Ahora</a
+          >
+        </div>
+      </div>`;
+      break;
+  }
+  switch (clientManagerContent) {
+    case "text":
+      content = html`<span>YourCompanyName/Logo</span>`;
+      break;
+    case "image":
+      content = html`<img src="https://via.placeholder.com/180x50" />`;
+      break;
+  }
+
+  return html`
+<!-- Font Proxima Nova -->
+<link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
+<section class="dp-container-fluid">
+    <div class="dp-rowflex">
+    ${messages}
+    <header class="header-main header-open ${
+      !hasDopplerLogo ? "dp-header--cm" : ""
+    }">
+        <div class="dp-logo--cm">
+          ${content}
+        </div>
+        <div class="header-wrapper">
+          <div class="logo" style="display:${
+            hasDopplerLogo ? "block" : "none"
+          }">
+            <a href="#">
+                <span class="ms-icon icon-doppler-logo"></span>
+            <a/>
+          </div>
+          <nav class="nav-left-main">
+            <div class="menu-main--container">
+              <ul class="menu-main">
+              <li><a href="#">Inicio</a></li>
+                <li class="submenu-item">
+                  <a href="#" class="active">Campañas</a>
+                  <ul class="sub-menu sub-campaings open">
+                    <li><a href="#" class="active">Borradores</a></li>
+                    <li><a href="#">Programadas</a></li>
+                    <li><a href="#">Enviadas</a></li>
+                    <li><a href="#">Test A/B</a></li>
+                  </ul>
+                  <!-- sub-menu -->
+                </li>
+                <li class="submenu-item">
+                  <a href="#">Listas</a>
+                  <ul class="sub-menu sub-list">
+                    <li><a href="#">Listas principales</a></li>
+                    <li><a href="#">Segmentos</a></li>
+                    <li><a href="#">Subscriptores</a></li>
+                    <li><a href="#">Campos personalizados</a></li>
+                    <li><a href="#">Formularios</a></li>
+                  </ul>
+                  <!-- sub-menu -->
+                </li>
+                <li><a href="#">Automatizaciones</a></li>
+                <li><a href="#">Reportes</a></li>
+                <li><a href="#">Plantillas</a></li>
+                <li><a href="#">Integraciones</a></li>
+              </ul>
+            </div>
+            <!-- menu-main--container only-mobile -->
+          </nav>
+          <!-- nav-left-main -->
+          <nav class="nav-right-main">
+            <ul class="nav-right-main--list">
+              <li>
+                <span class="user-menu--open active">
+                  <span class="ms-icon icon-notification"></span
+                ></span>
+                <div class="user-menu helper--right dp-notifications">
+                  <div class="dp-msj-notif" dp-dynamic-html="notification">
+                    <strong>NUEVO: Comportamiento en Sitio</strong>
+                    <br />
+                    <p>
+                      Programa un flujo automatizado de Emails que se envíe de
+                      acuerdo a las páginas que los Suscriptores hayan
+                      visitado en tu sitio.<br />
+                      <a href="#"><strong>PRUÉBALO GRATIS</strong></a> por
+                      tiempo limitado.
+                    </p>
+                  </div>
+                </div>
+              </li>
+              <li>
+                <a href="#"><span class="ms-icon icon-header-help"></span></a>
+              </li>
+              <li>
+                <a class="user-menu--open">
+                <span class="user-avatar">GB</span></a
+                >
+                <div class="user-menu">
+                  <!--open-->
+                  <header>
+                    <span class="user-avatar--menu">GB</span>
+                    <p>
+                      <span class="name">Gus Baamonde</span
+                      ><span class="email">gbaamonde@makingsense.com</span>
+                    </p>
+                  </header>
+                  <div class="user-plan--container m-t-18">
+                    <div class="user-plan--type">
+                      <p class="user-plan--monthly-text">
+                        <strong>Cuenta Gratis</strong> (500 Suscriptores)
+                      </p>
+                      <button
+                        class="user-plan close-user--menu"
+                        type="button"
+                      >
+                        comprar
+                      </button>
+                    </div>
+                    <div class="user-plan--type">
+                      <p><strong>498</strong> Suscriptores disponibles</p>
+                      <div class="dp-request-sent">
+                        <button
+                          class="user-plan close-user--menu dp-tooltip-left"
+                          type="button"
+                        >
+                          solicitud enviada
+                          <div class="tooltiptext">
+                            Estamos diseñando un Plan a la medida de tus
+                            necesidades.¡Te contactaremos pronto!
+                          </div>
+                        </button>
+                        <span class="ms-icon icon-info-icon"></span>
+                        <div class="dp-tooltip-container"></div>
+                      </div>
+                    </div>
+                    <div class="user-plan--type">
+                      <p><strong>250</strong> Suscriptores disponibles</p>
+                    </div>
+                  </div>
+                  <!-- user-plan--container -->
+                  <ul class="options-user">
+                    <li><a href="">Panel de Control</a></li>
+                    <li><a href="">Centro de descargas</a></li>
+                    <li><a href="">Primeros pasos en Doppler</a></li>
+                    <li><a href="">Salir</a></li>
+                  </ul>
+                </div>
+                <!-- user-menu -->
+              </li>
+            </ul>
+            <a id="open-menu" class="ms-icon icon-menu desktop-hd-hidden"></a>
+            <a
+              id="close-menu"
+              class="ms-icon icon-close desktop-hd-hidden"
+            ></a>
+          </nav>
+          <!-- nav-right-main -->
+        </div>
+        <!-- header-wrapper -->
+      </header>
+    </div>
+  </section>
+
+  `;
+};

--- a/src/stories/Header.stories.js
+++ b/src/stories/Header.stories.js
@@ -1,0 +1,31 @@
+import { Header } from "./Header";
+
+// More on default export:
+// https://storybook.js.org/docs/web-components/writing-stories/introduction#default-export
+export default {
+  title: "Components/Header",
+  // More on argTypes: https://storybook.js.org/docs/web-components/api/argtypes
+  argTypes: {
+    clientManagerContent: {
+      defaultValue: "none",
+      control: { type: "select" },
+      options: ["none", "text", "image"],
+    },
+    accountState: {
+      defaultValue: "none",
+      control: { type: "select" },
+      options: ["none", "info", "warning", "blocker"],
+    },
+  },
+};
+
+// More on component templates:
+// https://storybook.js.org/docs/web-components/writing-stories/introduction#using-args
+const Template = (args) => {
+  return Header(args);
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  hasDopplerLogo: true,
+};


### PR DESCRIPTION
### Create storybook template for user account header and messages
- add color variables
- add spacing variables

Figma: [mockup Header](https://www.figma.com/file/24sS51U589wMlAUmEntNyr/Navegaci%C3%B3n?node-id=126-2476&t=In76587pTvLNQEvS-0)

Storybook link: [Header Storybook](https://cdn.fromdoppler.com/doppler-style-guide/documentation/pr-262/storybook/?path=/story/components-header--default)