### PR TITLE
fix: do not init UserMenu behavior by default

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -2,7 +2,9 @@
 <script type="text/javascript">
   window["style-guide-configuration"] = {
     initDopplerMenuBehavior: true,
-    initUserMenuBehavior: true,
+    // This flag is only useful for documentation, it is incompatible with
+    // Menu MFE and should be moved out of the JS bundle
+    initUserMenuBehavior_DEPRECATED: true,
     initAccordionBehavior: true,
     initModalsBehavior: true,
     initDemonstrateBehavior: true,

--- a/src/documentation/templates/partials/_head.html
+++ b/src/documentation/templates/partials/_head.html
@@ -18,7 +18,9 @@
 <script type="text/javascript">
   window["style-guide-configuration"] = {
     initDopplerMenuBehavior: true,
-    initUserMenuBehavior: true,
+    // This flag is only useful for documentation, it is incompatible with
+    // Menu MFE and should be moved out of the JS bundle
+    initUserMenuBehavior_DEPRECATED: true,
     initAccordionBehavior: true,
     initModalsBehavior: true,
     initDemonstrateBehavior: true,

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import "./index.scss";
 import {
   initDopplerMenuBehavior,
-  initUserMenuBehavior,
+  initUserMenuBehavior_DEPRECATED,
   initAccordionBehavior,
   initModalsBehavior,
   initDemonstrateBehavior,
@@ -18,7 +18,9 @@ import {
 // autoInitialize flag is deprecated
 if (window["style-guide-configuration"]?.autoInitialize) {
   window["style-guide-configuration"].initDopplerMenuBehavior = true;
-  window["style-guide-configuration"].initUserMenuBehavior = true;
+  // This flag is only useful for documentation, it is incompatible with
+  // Menu MFE and should be moved out of the JS bundle
+  window["style-guide-configuration"].initUserMenuBehavior_DEPRECATED = false;
   window["style-guide-configuration"].initAccordionBehavior = true;
   window["style-guide-configuration"].initModalsBehavior = true;
   window["style-guide-configuration"].initDemonstrateBehavior = true;
@@ -35,8 +37,10 @@ if (window["style-guide-configuration"]?.autoInitialize) {
 if (window["style-guide-configuration"]?.initDopplerMenuBehavior) {
   initDopplerMenuBehavior();
 }
-if (window["style-guide-configuration"]?.initUserMenuBehavior) {
-  initUserMenuBehavior();
+// This flag is only useful for documentation, it is incompatible with
+// Menu MFE and should be moved out of the JS bundle
+if (window["style-guide-configuration"]?.initUserMenuBehavior_DEPRECATED) {
+  initUserMenuBehavior_DEPRECATED();
 }
 if (window["style-guide-configuration"]?.initAccordionBehavior) {
   initAccordionBehavior();

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -36,7 +36,9 @@ export const initDopplerMenuBehavior = function () {
   );
 };
 
-export const initUserMenuBehavior = function () {
+// This flag is only useful for documentation, it is incompatible with
+// Menu MFE and should be moved out of the JS bundle
+export const initUserMenuBehavior_DEPRECATED = function () {
   $("body")
     .on("click", ".user-menu--open", function () {
       $(this).parent().find(".user-menu").toggleClass("open");


### PR DESCRIPTION
UserMenu behavior is managed by React in Menu MFE, this javascript code conflicts with it and should not be enabled by default.

I did not remove the code because we need it to keep documentation demos working, it should be fixed in a future refactorization.