### PR TITLE
Add configuration to load Proxima Nova font

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -16,6 +16,7 @@
     initCarouselBehavior: true,
     initDropdownButtonBehavior: true,
     initExitEditorButtonBehavior: true,
+    initFonts: true,
   };
   assetServices.load({
     manifestURL: "%PUBLIC_URL%/asset-manifest.json",

--- a/src/documentation/templates/partials/_head.html
+++ b/src/documentation/templates/partials/_head.html
@@ -10,9 +10,6 @@
 <link rel="canonical" href="" />
 <!-- Open Graph metatags -->
 
-<!-- Font Proxima Nova -->
-<link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
-
 <!--Insert style guide using loader-->
 <script src="https://cdn.fromdoppler.com/mfe-loader/loader-v2.0.0.js"></script>
 <script type="text/javascript">
@@ -32,6 +29,7 @@
     initCarouselBehavior: true,
     initDropdownButtonBehavior: true,
     initExitEditorButtonBehavior: true,
+    initFonts: true,
   };
 
   const urlManifest = "%PUBLIC_URL%/asset-manifest.json";

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import {
   initCarouselBehavior,
   initDropdownButtonBehavior,
   initExitEditorButtonBehavior,
+  initFonts,
 } from "./js";
 
 // autoInitialize flag is deprecated
@@ -74,4 +75,8 @@ if (window["style-guide-configuration"]?.initDropdownButtonBehavior) {
 }
 if (window["style-guide-configuration"]?.initExitEditorButtonBehavior) {
   initExitEditorButtonBehavior();
+}
+
+if (window["style-guide-configuration"]?.initFonts) {
+  initFonts();
 }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -4,6 +4,7 @@ import "./PopupMenuLinks";
 import { Menubutton } from "./dropdown";
 import { PopupMenuLinks } from "./PopupMenuLinks";
 import { MenuItemLinks } from "./MenuItemLinks";
+export { initFonts } from "./initFonts";
 
 export const initDopplerMenuBehavior = function () {
   $("body").on(

--- a/src/js/initFonts.js
+++ b/src/js/initFonts.js
@@ -1,0 +1,10 @@
+export function initFonts() {
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  // Font Proxima Nova
+  link.href = "https://use.typekit.net/fbq8dbp.css";
+  const target =
+    document.getElementsByTagName("head")[0] ||
+    document.getElementsByTagName("body")[0];
+  target.appendChild(link);
+}

--- a/src/stories/Header.js
+++ b/src/stories/Header.js
@@ -60,8 +60,6 @@ export const Header = ({
   }
 
   return html`
-<!-- Font Proxima Nova -->
-<link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />
 <section class="dp-container-fluid">
     <div class="dp-rowflex">
     ${messages}


### PR DESCRIPTION
Adding an optional configuration `window["style-guide-configuration"].initFonts`

When it is true, the _Style Guide_ will append `<link rel="stylesheet" href="https://use.typekit.net/fbq8dbp.css" />` into the `<head>` element loading _Proxima Nova_ font.

I am not sure if we should make it optional or always load this font. Thoughts?

See [documentation](https://cdn.fromdoppler.com/doppler-style-guide/documentation/pr-288) and [storybook](https://cdn.fromdoppler.com/doppler-style-guide/documentation/pr-288/storybook/).