### PR TITLE
fix: complete change of input file component for accessibility

### DIFF
--- a/src/assets/scss/modules/_inputs.scss
+++ b/src/assets/scss/modules/_inputs.scss
@@ -582,115 +582,96 @@
   /* Input file PDF */
 
   .dp-label-dropfile {
-    position: relative;
-    display: flex;
-    align-items: center;
-    border: 1px dashed colors.$dp-color-green;
-    border-radius: var.$dp-border-radius;
-    padding: var.$dp-spaces--lv2;
-    cursor: pointer;
+    font-size: 13px;
 
-    &::before {
-      content: attr(data-dropfile);
-      color: colors.$dp-color-grey;
-      font-size: typography.$dp-label-fontsize-base;
-      line-height: 18px;
-      top: -24px;
-      left: 0;
-      position: absolute;
-      text-align: center;
+    input[type="file"] {
+      width: 100%;
+      height: 100%;
+      border: 1px dashed colors.$dp-color-green;
+      border-radius: var.$dp-border-radius;
+      padding: var.$dp-spaces--lv2;
+      cursor: pointer;
+      color: colors.$dp-color-darkgrey;
+      margin-top: var.$dp-spaces--lv1;
+      font-size: 13px;
+      line-height: 30px;
     }
 
-    &::after {
-      content: attr(data-legend);
-      font-size: typography.$dp-label-fontsize-base;
-      line-height: 18px;
-      bottom: -24px;
-      right: 0;
-      position: absolute;
-      font-style: italic;
-      font-weight: normal;
-      line-height: 18px;
-      font-size: var.$dp-sizing--lvl2-14;
-      color: colors.$dp-color-lightgrey;
-    }
-
-    &:hover,
-    &:active {
+    input[type="file"]:active,
+    input[type="file"]:hover {
       background: colors.$dp-greenBackground-forWords;
     }
 
-    .dp-drop-placeholder {
-      margin-right: var.$dp-spaces--lv2;
-      font-weight: normal;
-      color: colors.$dp-color-darkgrey;
+    input[type="file"]::-webkit-file-upload-button,
+    input[type="file"]::file-selector-button {
+      color: colors.$dp-color-darkgreen;
+      border: 1px solid colors.$dp-color-darkgreen;
+      background-color: colors.$dp-color-white;
+      display: inline-block;
+      font-size: 13px;
+      text-align: center;
+      text-decoration: none;
+      appearance: none;
+      cursor: pointer;
+      font-family: "proxima-nova", Helvetica, Arial, sans-serif;
+      border-radius: 3px;
+      letter-spacing: 0.6px;
+      transition: all 0.35s ease;
+      margin-right: var.$dp-spaces--lv3;
+      -webkit-appearance: button;
+      font: inherit;
+      min-width: 150px;
     }
 
-    .dp-button.secondary-green {
-      background: colors.$dp-color-white;
+    .assistance-wrap span {
+      font-size: 13px;
+      color: colors.$dp-color-lightgrey;
+      font-style: italic;
     }
-  }
-
-  .dp-label-dropfile[aria-invalid="true"] {
-    border: 1px dashed colors.$dp-color-error-border;
-    box-shadow: out 0 0 0 2px colors.$dp-color-error-border;
   }
 
   /// Disabled
 
-  .dp-label-dropfile[aria-disabled="true"] {
+  .dp-label-dropfile[aria-disabled="true"] input[type="file"] {
     border: 1px dashed colors.$dp-color-disabled-checkbox;
     color: colors.$dp-color-lightgrey;
     pointer-events: none;
+  }
 
-    .dp-drop-placeholder {
-      color: colors.$dp-color-lightgrey;
-    }
+  .dp-label-dropfile[aria-disabled="true"] input[type="file"]:active,
+  .dp-label-dropfile[aria-disabled="true"] input[type="file"]:hover {
+    background-color: #eaeaea;
+  }
 
-    .dp-button.secondary-green {
-      border: 1px solid colors.$dp-color-disabled-checkbox;
-      color: colors.$dp-color-disabled-checkbox;
-      box-shadow: none;
-    }
-
-    &:hover,
-    &:active {
-      background: colors.$dp-color-white;
-    }
+  .dp-label-dropfile[aria-disabled="true"]
+    input[type="file"]::-webkit-file-upload-button,
+  .dp-label-dropfile[aria-disabled="true"]
+    input[type="file"]::file-selector-button {
+    pointer-events: none;
+    color: colors.$dp-color-lightgrey;
+    border: 1px solid colors.$dp-color-disabled-checkbox;
   }
 
   /// Error
 
   .dp-label-dropfile[aria-invalid="true"] {
+    color: colors.$dp-color-content-error;
+
+    input[type="file"]::-webkit-file-upload-button,
+    input[type="file"]::file-selector-button {
+      color: colors.$dp-color-content-error;
+      border: 1px solid colors.$dp-color-error-border;
+      background-color: colors.$dp-color-white;
+    }
+    .assistance-wrap span {
+      font-size: 13px;
+      color: colors.$dp-color-content-error;
+    }
+  }
+  .dp-label-dropfile[aria-invalid="true"] input[type="file"] {
     border: 1px dashed colors.$dp-color-error-border;
     color: colors.$dp-color-content-error;
     background: url(assets/img/error-form.svg) no-repeat 0 0;
     background-position: right 0.5em center;
-
-    &::after,
-    &::before {
-      color: colors.$dp-color-content-error;
-    }
-
-    .dp-drop-placeholder {
-      color: colors.$dp-color-content-error;
-    }
-
-    .dp-button.secondary-green {
-      border: 1px solid colors.$dp-color-error-border;
-      color: colors.$dp-color-content-error;
-      box-shadow: none;
-    }
-
-    &:hover,
-    &:active {
-      background: colors.$dp-color-white;
-      background: url(assets/img/error-form.svg) no-repeat 0 0;
-      background-position: right 0.5em center;
-    }
-  }
-
-  label.dp-label-dropfile[aria-invalid="true"] > span::before {
-    display: none;
   }
 }

--- a/src/documentation/templates/component-inputs.html
+++ b/src/documentation/templates/component-inputs.html
@@ -157,61 +157,18 @@
                       value=""
                     /> -->
                   </li>
-                  <!-- <li class="field-item col-sm-4 m-b-12">
-                    <label role="checkbox">
-                      <input type="checkbox" disabled />
-                      <span>Checkbox disabled</span>
-                    </label>
-                  </li>
-                  <li class="field-item col-sm-4 m-b-12">
-                    <label role="checkbox">
-                      <input type="checkbox" />
-                      <span>Checkbox hover</span>
-                    </label>
-                  </li>
-                  <li class="field-item col-sm-4 m-b-12">
-                    <label
-                      role="checkbox"
-                      aria-invalid="true"
-                      aria-errormessage="errmsj1"
-                    >
-                      <input type="checkbox" />
-                      <span
-                        >Checkbox error o algo mas largo como una politica de
-                        privacidad</span
-                      >
-                    </label>
-                    <p id="errmsj1" class="dp-errormessage">
-                      ¡Ouch! Este checkbox no esta tildado. quizas algo mas
-                      largo como dos lineas
-                    </p>
-                  </li> -->
                   <li class="field-item col-sm-6 m-b-12 m-t-36">
                     <label
-                      id="drop-zone"
-                      for="pdf"
-                      class="dp-label-dropfile"
-                      data-dropfile="*Constancia de situación fiscal"
-                      data-legend="Debe ser menor a 25 megas"
+                      class="dp-label-dropfile m-t-54"
+                      for="file"
                       aria-disabled="false"
-                      aria-invalid="false"
+                      aria-invalid="true"
                     >
-                      <span class="dp-drop-placeholder"
-                        >Arrastrar archivo aquí o</span
-                      >
-                      <input
-                        type="file"
-                        id="pdf"
-                        accept="application/pdf"
-                        hidden
-                        onchange="console.log('se seleccionaron')"
-                      />
-                      <span
-                        role="button"
-                        class="dp-button button-small secondary-green"
-                      >
-                        Cargar archivo
-                      </span>
+                      *Constancia de situación fiscal
+                      <input type="file" id="file" name="file" />
+                      <div class="assistance-wrap">
+                        <span>Debe ser menor a 25 megas</span>
+                      </div>
                     </label>
                   </li>
                 </ul>

--- a/src/stories/Inputs.file.js
+++ b/src/stories/Inputs.file.js
@@ -3,35 +3,20 @@ import { html } from "lit-html";
 /**
  * Primary UI component for user interaction
  */
-export const Inputs = ({
-  disabled,
-  label,
-  labelPlaceholder,
-  labelLegend,
-  isError,
-}) => {
+export const Inputs = ({ disabled, label, labelLegend, isError }) => {
   return html`
-    <div class="awa-form m-t-42" style="width:450px;">
+    <div class="awa-form" style="width:450px;">
       <label
-        id="drop-zone"
-        for="pdf"
         class="dp-label-dropfile"
-        data-dropfile="${label}"
-        data-legend="${labelLegend}"
+        for="file"
         aria-disabled="${disabled}"
         aria-invalid="${isError}"
       >
-        <span class="dp-drop-placeholder">${labelPlaceholder}</span>
-        <input
-          type="file"
-          id="pdf"
-          accept="application/pdf"
-          hidden
-          onchange="console.log('se seleccionaron')"
-        />
-        <span role="button" class="dp-button button-small secondary-green">
-          Cargar archivo
-        </span>
+        ${label}
+        <input type="file" id="file" name="file" .disabled="${disabled}" />
+        <div class="assistance-wrap">
+          <span>${labelLegend}</span>
+        </div>
       </label>
     </div>
   `;

--- a/src/stories/Inputs.file.stories.js
+++ b/src/stories/Inputs.file.stories.js
@@ -20,5 +20,4 @@ Default.args = {
   isError: false,
   label: "*Constancia de situación fiscal",
   labelLegend: "Debe ser menor a 25 megas",
-  labelPlaceholder: "Arrastrar archivo aquí o",
 };


### PR DESCRIPTION
Cambie por completo el componente input file.
Anteriormente utilice los [data-attributes](https://developer.mozilla.org/es/docs/Learn/HTML/Howto/Use_data_attributes) para colocar mensajes de cara al usuario y manipularlos por CSS.
Si bien la fácil manipulación por CSS es una tentación, descubrí que **NO son accesibles** y el componente **pierde su semántica**, transformándose en una **mala practica** y en un componente inservible.

El nuevo componente presentado trabaja de forma nativa, perdemos un poco en diseño, pero nos queda un componente completamente accesible y semántico.
Dejo beneficios y contras por las dudas.

**Contras:**

- El diseño no queda tal cual el mockup
- No puedo manipular el mensaje del botón ni su placeholder, ya que el DOM toma por defecto el idioma y cada Browser utiliza su propio mensaje para cada caso.
- Los estilo que se le pueden dar no son muchos.

**Beneficios:**
- Ganamos la navegación por teclado. 
- Es accesible y semántico.
- Nos despreocupamos de las traducciones ya que el idioma lo maneja el Browser.
- Código mas pequeño y performante.
- Fácil implementación.
- Crossbrowser.
- el diseño es muy parecido, utilice como guía  **::file-selector-button** [(documentacion link)](https://developer.mozilla.org/en-US/docs/Web/CSS/::file-selector-button)

[Dejo link en Storybook para probarlo](https://cdn.fromdoppler.com/doppler-style-guide/documentation/pr-303/storybook/?path=/story/components-inputs-file--default)

**Videos de muestra:**

### Upload file   --------------------------------------------------------------------------------------------------------------------

![upload-file](https://github.com/FromDoppler/doppler-style-guide/assets/46735526/648597b2-1a66-460d-98cf-cce5ef10ea57)


### Chrome   --------------------------------------------------------------------------------------------------------------------

![chrome](https://github.com/FromDoppler/doppler-style-guide/assets/46735526/1be5f7e9-8bc8-4ca8-8c2d-d275249fbb0b)

### Microsoft Edge   -----------------------------------------------------------------------------------------------------------------

![Microsoft-Edge](https://github.com/FromDoppler/doppler-style-guide/assets/46735526/8b94bc22-5788-408d-82d9-aea05b9f331c)


### Mozilla   --------------------------------------------------------------------------------------------------------------------

![Mozilla](https://github.com/FromDoppler/doppler-style-guide/assets/46735526/885bcf5b-43f8-447e-89d1-6c961ceeadd8)
