### PR TITLE
fix: add validation input password

### DIFF
--- a/src/assets/scss/modules/_inputs.scss
+++ b/src/assets/scss/modules/_inputs.scss
@@ -429,6 +429,17 @@
     @extend %input-type;
   }
 
+  .labelpassword
+    input[type="password"][aria-invalid="true"]
+    + .assistance-wrap
+    span,
+  .labelpassword
+    input[type="password"][aria-invalid="true"]
+    + .assistance-wrap
+    p {
+    color: colors.$dp-color-content-error;
+  }
+
   /// Label Required
 
   .labelpassword[data-required="true"]::before {
@@ -471,10 +482,9 @@
   .labelpassword .dp-wrap-eyed {
     display: flex;
     flex-direction: column;
-    align-items: end;
     justify-content: center;
     height: 100%;
-    margin-top: var.$dp-spaces--lv1;
+    position: relative;
   }
 
   .labelpassword .dp-wrap-eyed .show-hide {
@@ -487,6 +497,7 @@
     padding: var.$dp-spaces--lv1;
     position: absolute;
     right: var.$dp-spaces--lv1;
+    top: 10px;
   }
 
   .labelpassword .dp-wrap-eyed .icon-hide:before,

--- a/src/documentation/templates/component-inputs.html
+++ b/src/documentation/templates/component-inputs.html
@@ -116,6 +116,9 @@
                           aria-invalid="false"
                           aria-placeholder="Your Password"
                         />
+                        <div class="assistance-wrap">
+                          <span>Assistive text</span>
+                        </div>
                       </div>
                       <div class="wrapper-password">
                         <p class="password-message">

--- a/src/stories/Inputs.password.js
+++ b/src/stories/Inputs.password.js
@@ -28,6 +28,9 @@ export const Inputs = ({ disabled, label, labelRequired, isError }) => {
             aria-invalid="${isError}"
             aria-placeholder="Your Password"
           />
+          <div class="assistance-wrap">
+            <span>Assistive text</span>
+          </div>
         </div>
         <div class="wrapper-password">
           <p class="password-message">


### PR DESCRIPTION
[Link Storybook](https://cdn.fromdoppler.com/doppler-style-guide/documentation/pr-325/storybook/?path=/story/components-inputs-password--default)



![add-validation-password](https://github.com/FromDoppler/doppler-style-guide/assets/46735526/45e9ad16-9a21-4d80-aa66-7410747269e3)
