### PR TITLE
fix: improve image gallery checkbox

### DIFF
--- a/src/assets/scss/helpers/_classes.scss
+++ b/src/assets/scss/helpers/_classes.scss
@@ -714,22 +714,30 @@
       left: 8px;
       width: 1.4em;
       height: 1.4em;
-      border-radius: 0.3em;
       background-color: #fafafa;
       box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05),
         inset 0px -15px 10px -12px rgba(0, 0, 0, 0.05);
+      border: solid 1px #838370;
 
       &:focus {
         top: unset;
         left: 8px;
       }
 
+      &:checked {
+        background-color: colors.$dp-color-ok-checkbox;
+      }
+
       &:checked::after {
-        content: "\2714";
+        content: "";
         position: absolute;
+        left: 6px;
         top: 3px;
-        left: 3px;
-        color: #99a1a7;
+        width: 5px;
+        height: 10px;
+        border: solid #fff;
+        border-width: 0 3px 3px 0;
+        transform: rotate(45deg);
       }
     }
   }


### PR DESCRIPTION

![image](https://github.com/FromDoppler/doppler-style-guide/assets/1157864/e020aaa0-c68d-4a91-a529-8c312eb95510)

It is not exactly the same checkbox, but it is pretty similar.