### PR TITLE
fix: change type text to type number in input phone

### DIFF
--- a/src/assets/scss/modules/_inputs.scss
+++ b/src/assets/scss/modules/_inputs.scss
@@ -312,6 +312,18 @@
   .labelcontrol input[type="tel"] {
     @extend %input-type;
     padding-left: 45px;
+    appearance: none;
+  }
+
+  .labelcontrol input[type="number"] {
+    @extend %input-type;
+    padding-left: 45px;
+    appearance: none;
+  }
+
+  .labelcontrol input[type="number"]::-webkit-inner-spin-button,
+  .labelcontrol input[type="number"]::-webkit-outer-spin-button {
+    display: none;
   }
 
   .labelcontrol input[type="email"] {
@@ -433,6 +445,11 @@
     font-style: normal;
   }
 
+  .labelcontrol input[type="number"]::placeholder {
+    color: colors.$dp-color-text-input;
+    font-style: normal;
+  }
+
   .labelcontrol input[type="tel"]::placeholder {
     color: colors.$dp-color-text-input;
     font-style: normal;
@@ -447,6 +464,12 @@
   }
 
   .labelcontrol input[type="email"]:focus {
+    outline: none;
+    border: 1px solid colors.$dp-color-darkyellow;
+    box-shadow: 0 0 0 2px colors.$dp-color-darkyellow;
+  }
+
+  .labelcontrol input[type="number"]:focus {
     outline: none;
     border: 1px solid colors.$dp-color-darkyellow;
     box-shadow: 0 0 0 2px colors.$dp-color-darkyellow;

--- a/src/documentation/templates/component-inputs.html
+++ b/src/documentation/templates/component-inputs.html
@@ -151,7 +151,7 @@
                       data-required="true"
                       >Teléfono
                       <input
-                        type="tel"
+                        type="number"
                         id="tel"
                         name="tel"
                         placeholder="Your Phone"

--- a/src/stories/Inputs.phone.js
+++ b/src/stories/Inputs.phone.js
@@ -15,7 +15,7 @@ export const Inputs = ({ disabled, label, labelRequired, isError }) => {
         ${label}
         <div class="iti iti--allow-dropdown">
           <input
-            type="tel"
+            type="number"
             id="tel"
             name="tel"
             placeholder="Your Phone"


### PR DESCRIPTION
To see in [Storybook](https://cdn.fromdoppler.com/doppler-style-guide/documentation/pr-348/storybook/?path=/story/components-inputs-phone--default)

![change-type-number](https://github.com/FromDoppler/doppler-style-guide/assets/46735526/0f82400b-130c-44c6-8f8c-452e9406d742)
