### PR TITLE
fix: add new disabled state to switch buttons

### DIFF
--- a/src/assets/scss/modules/_buttons.scss
+++ b/src/assets/scss/modules/_buttons.scss
@@ -437,6 +437,20 @@
       left: 1px;
     }
 
+    input[type="checkbox"]:disabled
+      + label[aria-disabled="true"]
+      span:last-child {
+      background-color: colors.$dp-color-ghostwhite;
+      cursor: text;
+    }
+
+    input[type="checkbox"]:disabled
+      + label[aria-disabled="true"]
+      span:last-child::before {
+      background-color: colors.$dp-color-silver;
+      cursor: text;
+    }
+
     label {
       display: flex;
       align-items: center;

--- a/src/documentation/templates/buttons-component.html
+++ b/src/documentation/templates/buttons-component.html
@@ -415,8 +415,8 @@
 
                       <div class="dp-text-switch m-b-12 m-t-24">
                         <div class="dp-switch">
-                          <input type="checkbox" id="oneCheck" checked />
-                          <label for="oneCheck">
+                          <input type="checkbox" id="oneCheck" />
+                          <label for="oneCheck" aria-disabled="false">
                             <span></span>
                           </label>
                         </div>

--- a/src/stories/Switch.Button.js
+++ b/src/stories/Switch.Button.js
@@ -1,0 +1,60 @@
+import { html } from "lit-html";
+
+/**
+ * Primary UI component for user interaction
+ */
+export const Inputs = ({ disabled, label, labelRequired, isError }) => {
+  return html` <div class="m-t-42">
+    <h2>Nuetro Switch Button tiene tres estados</h2>
+    <h3>Checked</h3>
+    <div
+      class="dp-text-switch m-b-24"
+      style="width: 400px; border-bottom: 1px solid #CCC;
+    padding: 18px 0;"
+    >
+      <div class="dp-switch">
+        <input type="checkbox" id="oneCheck1" checked />
+        <label for="oneCheck1" aria-disabled="false">
+          <span></span>
+        </label>
+      </div>
+      <p>
+        Solo hay que agregar el <strong>atributo "checked"</strong> al
+        <strong>"input"</strong>, de esta manera nos queda semántico y
+        accesible.
+      </p>
+    </div>
+    <h3>Unchecked</h3>
+    <div
+      class="dp-text-switch m-b-24"
+      style="width: 400px; border-bottom: 1px solid #CCC;
+    padding: 18px 0;"
+    >
+      <div class="dp-switch">
+        <input type="checkbox" id="oneCheck2" />
+        <label for="oneCheck2" aria-disabled="false">
+          <span></span>
+        </label>
+      </div>
+      <p>
+        En este caso no es necesario agregar ningún atributo al elemento
+        <strong>"input"</strong>.
+      </p>
+    </div>
+    <h3>Disabled</h3>
+    <div class="dp-text-switch m-b-24" style="width: 400px;padding: 18px 0;">
+      <div class="dp-switch">
+        <input type="checkbox" id="oneCheck" disabled />
+        <label for="oneCheck" aria-disabled="true">
+          <span></span>
+        </label>
+      </div>
+      <p>
+        En su variante de deshabilitado solo necesitamos agregar el atributo
+        <strong>"disabled"</strong> al <strong>"input"</strong> y
+        <strong>"aria-disabled="true"</strong> al elemento
+        <strong>"label"</strong>.
+      </p>
+    </div>
+  </div>`;
+};

--- a/src/stories/Switch.Button.stories.js
+++ b/src/stories/Switch.Button.stories.js
@@ -1,0 +1,18 @@
+import { Inputs } from "./Switch.Button";
+
+// More on default export:
+// https://storybook.js.org/docs/web-components/writing-stories/introduction#default-export
+export default {
+  title: "Components/Switch.Button",
+  // More on argTypes: https://storybook.js.org/docs/web-components/api/argtypes
+  argTypes: {},
+};
+
+// More on component templates:
+// https://storybook.js.org/docs/web-components/writing-stories/introduction#using-args
+const Template = (args) => {
+  return Inputs(args);
+};
+
+export const Default = Template.bind({});
+Default.args = {};


### PR DESCRIPTION
[Link Storybook -->](https://cdn.fromdoppler.com/doppler-style-guide/documentation/pr-381/storybook/?path=/story/components-switch-button--default)

![states-switch-buttons](https://github.com/FromDoppler/doppler-style-guide/assets/46735526/27f5acb0-ea11-4434-9f1c-497c448afe78)
