### PR TITLE
fix: fix font size in messages for users

### DIFF
--- a/src/assets/scss/modules/_messages.scss
+++ b/src/assets/scss/modules/_messages.scss
@@ -111,8 +111,10 @@
       width: 100%;
 
       p {
-        font-size: var.$dp-sizing--lvl2;
-        line-height: 18px;
+        font-size: typography.$dp-fontsize-awa;
+        line-height: 24px;
+        font-family: typography.$dp-fontfamily-awa;
+        color: colors.$dp-color-darkgrey;
       }
     }
 
@@ -133,17 +135,19 @@
       .dp-message-link {
         margin-top: var.$dp-spaces--lv0;
         min-width: 154px;
+        text-align: right;
       }
     }
 
     .dp-message-link {
-      text-transform: uppercase;
       color: colors.$dp-color-darkgrey;
       text-decoration: underline;
-      font-size: var.$dp-sizing--lvl2;
-      text-align: right;
+      text-align: left;
       margin-top: var.$dp-spaces--lv2;
       display: inline-block;
+      font-size: typography.$dp-fontsize-awa;
+      line-height: 24px;
+      font-family: typography.$dp-fontfamily-awa;
     }
   }
 

--- a/src/stories/Messages.for.user.js
+++ b/src/stories/Messages.for.user.js
@@ -1,0 +1,165 @@
+import { html } from "lit-html";
+
+/**
+ * Primary UI component for user interaction
+ */
+export const isoText = ({}) => {
+  return html`
+    <div style="width: 100%; margin-top: 45px; padding-left: 60px;">
+      <div class="dp-container m-t-42">
+        <div class="dp-rowflex">
+          <div class="col-md-4 m-b-12">
+            <h4 class="m-b-24">Success message</h4>
+            <div class="dp-wrap-message dp-wrap-success">
+              <span class="dp-message-icon"></span>
+              <div class="dp-content-message">
+                <p>Cambios guardados con éxito.</p>
+              </div>
+            </div>
+          </div>
+          <div class="col-md-4 m-b-12">
+            <h4 class="m-b-24">Warning MEssage</h4>
+            <div class="dp-wrap-message dp-wrap-warning">
+              <span class="dp-message-icon"></span>
+              <div class="dp-content-message">
+                <p>Ten cuidado.</p>
+              </div>
+            </div>
+          </div>
+          <div class="col-md-4 m-b-12">
+            <h4 class="m-b-24">Error Message</h4>
+            <div class="dp-wrap-message dp-wrap-cancel">
+              <span class="dp-message-icon"></span>
+              <div class="dp-content-message">
+                <p>¡Ouch! Ha habido un problema.</p>
+              </div>
+            </div>
+          </div>
+          <div class="col-md-4 m-t-42 m-b-12">
+            <h4 class="m-b-24">INFORMATION message</h4>
+            <div class="dp-wrap-message dp-wrap-info">
+              <span class="dp-message-icon"></span>
+              <div class="dp-content-message">
+                <p>Cambios guardados con éxito.</p>
+              </div>
+            </div>
+          </div>
+          <div class="col-md-4 m-t-42 m-b-12"></div>
+          <div class="col-md-4 m-t-42 m-b-12"></div>
+          <div class="col-md-4 m-b-12">
+            <h4 class="m-t-24 m-b-24">Success message - EDITORS - WITH LINK</h4>
+            <div class="dp-wrap-message dp-wrap-success">
+              <span class="dp-message-icon"></span>
+              <div class="dp-content-message">
+                <p>
+                  Utilizar dominios públicos como Hotmail, Gmail, Yahoo u otros,
+                  afecta la Tasa de Apertura. Si tienes dudas, presiona Help.
+                </p>
+                <a href="#" class="dp-message-link">Entendido</a>
+              </div>
+            </div>
+          </div>
+          <div class="col-md-4 m-b-12">
+            <h4 class="m-t-24 m-b-24">Warning MEssage - EDITORS - WITH LINK</h4>
+            <div class="dp-wrap-message dp-wrap-warning">
+              <span class="dp-message-icon"></span>
+              <div class="dp-content-message">
+                <p>
+                  Utilizar dominios públicos como Hotmail, Gmail, Yahoo u otros,
+                  afecta la Tasa de Apertura. Si tienes dudas, presiona Help.
+                </p>
+                <a href="#" class="dp-message-link">Entendido</a>
+              </div>
+            </div>
+          </div>
+          <div class="col-md-4 m-b-12">
+            <h4 class="m-t-24 m-b-24">Error Message - EDITORS - WITH LINK</h4>
+            <div class="dp-wrap-message dp-wrap-cancel">
+              <span class="dp-message-icon"></span>
+              <div class="dp-content-message">
+                <p>
+                  ¡Ouch! Debido a la cantidad de Suscriptores, debes configurar
+                  un dominio propio para hacer este envío. Si tienes dudas,
+                  presiona Help.
+                </p>
+                <a href="#" class="dp-message-link">Configura tu dominio</a>
+              </div>
+            </div>
+          </div>
+          <div class="col-md-4 m-b-12">
+            <h4 class="m-t-24 m-b-24">Success message - EDITORS - WITH LINK</h4>
+            <div class="dp-wrap-message dp-wrap-info">
+              <span class="dp-message-icon"></span>
+              <div class="dp-content-message">
+                <p>
+                  Utilizar dominios públicos como Hotmail, Gmail, Yahoo u otros,
+                  afecta la Tasa de Apertura. Si tienes dudas, presiona Help.
+                </p>
+                <a href="#" class="dp-message-link">Entendido</a>
+              </div>
+            </div>
+          </div>
+          <div class="col-md-4 m-b-12"></div>
+          <div class="col-md-4 m-b-12"></div>
+          <div class="col-md-12 m-b-12 m-t-42">
+            <h4 class="m-t-24 m-b-24">
+              Success message - FULL WIDTH - WITH LINK
+            </h4>
+            <div class="dp-wrap-message dp-wrap-success">
+              <span class="dp-message-icon"></span>
+              <div class="dp-content-message dp-content-full">
+                <p>
+                  Utilizar dominios públicos como Hotmail, Gmail, Yahoo u otros,
+                  afecta la Tasa de Apertura. Si tienes dudas, presiona Help.
+                </p>
+                <a href="#" class="dp-message-link">Entendido</a>
+              </div>
+            </div>
+          </div>
+          <div class="col-md-12 m-b-12">
+            <h4 class="m-t-24 m-b-24">Warning MEssage - FULL WIDTH</h4>
+            <div class="dp-wrap-message dp-wrap-warning">
+              <span class="dp-message-icon"></span>
+              <div class="dp-content-message dp-content-full">
+                <p>
+                  Utilizar dominios públicos como Hotmail, Gmail, Yahoo u otros,
+                  afecta la Tasa de Apertura. Si tienes dudas, presiona Help.
+                </p>
+                <a href="#" class="dp-message-link">Entendido</a>
+              </div>
+            </div>
+          </div>
+          <div class="col-md-12 m-b-12">
+            <h4 class="m-t-24 m-b-24">Error Message - FULL WIDTH</h4>
+            <div class="dp-wrap-message dp-wrap-cancel">
+              <span class="dp-message-icon"></span>
+              <div class="dp-content-message dp-content-full">
+                <p>
+                  ¡Ouch! Debido a la cantidad de Suscriptores, debes configurar
+                  un dominio propio para hacer este envío. Si tienes dudas,
+                  presiona Help.
+                </p>
+                <a href="#" class="dp-message-link">Configura tu dominio</a>
+              </div>
+            </div>
+          </div>
+          <div class="col-md-12 m-b-12">
+            <h4 class="m-t-24 m-b-24">
+              Success message - FULL WIDTH - WITH LINK
+            </h4>
+            <div class="dp-wrap-message dp-wrap-info">
+              <span class="dp-message-icon"></span>
+              <div class="dp-content-message dp-content-full">
+                <p>
+                  Has configurado correctamente tu dominio. Para mas
+                  información, presiona Help.
+                </p>
+                <a href="#" class="dp-message-link">Configura tu dominio</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+};

--- a/src/stories/Messages.for.user.stories.js
+++ b/src/stories/Messages.for.user.stories.js
@@ -1,0 +1,18 @@
+import { isoText } from "./Messages.for.user";
+
+// More on default export:
+// https://storybook.js.org/docs/web-components/writing-stories/introduction#default-export
+export default {
+  title: "Components/Messages.for.user",
+  // More on argTypes: https://storybook.js.org/docs/web-components/api/argtypes
+  argTypes: {},
+};
+
+// More on component templates:
+// https://storybook.js.org/docs/web-components/writing-stories/introduction#using-args
+const Template = (args) => {
+  return isoText(args);
+};
+
+export const Default = Template.bind({});
+Default.args = {};


### PR DESCRIPTION
### [Link Storybook -->](https://cdn.fromdoppler.com/doppler-style-guide/documentation/pr-412/storybook/?path=/story/components-messages-for-user--default)



![font-size-for-messages](https://github.com/FromDoppler/doppler-style-guide/assets/46735526/9c395009-ae9c-4498-a0a1-7bbeed59675d)
