### PR TITLE
fix: change in storybook types of plans

### DIFF
--- a/src/stories/Types.Of.Plans.js
+++ b/src/stories/Types.Of.Plans.js
@@ -83,13 +83,20 @@ export const Inputs = ({ disabled }) => {
                       </div>
                       <div class="dp-price">
                         <span>Desde</span>
+                        <span class="dp-discount-price-arg"
+                          >US$ 62.999/mes**</span
+                        >
                         <h3>US$X,00*/mes</h3>
                         <button
                           type="button"
-                          class="dp-button button-medium primary-green dp-uppercase"
+                          class="dp-button button-medium dp-uppercase dp-secondary-blue"
                         >
                           Calcular valor
                         </button>
+                        <span class="dp-off"
+                          ><strong>20% OFF</strong> Exclusivo para
+                          Argentina</span
+                        >
                       </div>
                       <hr class="dp-border" />
                       <div class="dp-whatcan">


### PR DESCRIPTION
[Link Storybook ](https://cdn.fromdoppler.com/doppler-style-guide/documentation/pr-465/storybook/?path=/story/components-types-of-plans--default)

![change-types-of-plans](https://github.com/FromDoppler/doppler-style-guide/assets/46735526/39d81958-b49e-49e5-ac80-389796237090)
