### PR TITLE
[DOI-1728] Add missing styles for widget hover card

### DIFF
--- a/src/assets/scss/modules/_widget-card.scss
+++ b/src/assets/scss/modules/_widget-card.scss
@@ -66,6 +66,16 @@
     z-index: 3;
     border-radius: 5px;
   }
+
+  &-hover-message h3,
+  &-hover-message a,
+  &-hover-message p {
+    color: colors.$dp-color-white;
+  }
+
+  &-hover-message a:hover {
+    color: colors.$dp-color-blue;
+  }
 }
 
 .dp-widget-info-card {


### PR DESCRIPTION
There are some texts missing the right color. Now its like defined in the figma.
Also added a hover color for the link. I have to check that with the design team.

![image](https://github.com/user-attachments/assets/e57444c4-3ba3-468b-98b1-e40efcfb7976)
