### PR TITLE
Dph #138 label with tooltip

### DIFF
--- a/src/assets/scss/modules/_inputs.scss
+++ b/src/assets/scss/modules/_inputs.scss
@@ -970,3 +970,8 @@
     }
   }
 }
+
+.dp-label-with-icon {
+  display: flex;
+  align-items: center;
+}

--- a/src/assets/scss/modules/_tooltip.scss
+++ b/src/assets/scss/modules/_tooltip.scss
@@ -72,15 +72,15 @@
       display: inline-block;
       font-weight: normal;
     }
+  }
 
-    .dp-tooltip-top-bubble {
-      max-width: 180px;
-      font-size: variables.$dp-sizing--lvl2;
-      line-height: variables.$dp-spaces--lv3;
-      text-align: center;
-      display: inline-block;
-      font-weight: normal;
-    }
+  .dp-tooltip-top-bubble {
+    max-width: 180px;
+    font-size: variables.$dp-sizing--lvl2;
+    line-height: variables.$dp-spaces--lv3;
+    text-align: center;
+    display: inline-block;
+    font-weight: normal;
   }
 
   .dp-tooltip-top {

--- a/src/assets/scss/modules/_tooltip.scss
+++ b/src/assets/scss/modules/_tooltip.scss
@@ -72,6 +72,15 @@
       display: inline-block;
       font-weight: normal;
     }
+
+    .dp-tooltip-top-bubble {
+      max-width: 180px;
+      font-size: variables.$dp-sizing--lvl2;
+      line-height: variables.$dp-spaces--lv3;
+      text-align: center;
+      display: inline-block;
+      font-weight: normal;
+    }
   }
 
   .dp-tooltip-top {


### PR DESCRIPTION
- Add `dp-tooltip-top-bubble` class to avoid class overlap on `.dp-tooltip-top > span` and  `input--radio label span`
- Add `dp-label-with-icon` class to properly align label text and icon

![image](https://github.com/user-attachments/assets/e351ba8e-f057-41e1-9c93-86567dc1d8b1)
