### PR TITLE
[DOI-1895] Add new component "widget plan progress bar"

### DIFF
--- a/src/assets/scss/modules/_widget-card.scss
+++ b/src/assets/scss/modules/_widget-card.scss
@@ -152,3 +152,42 @@
     }
   }
 }
+
+.dp-widget-plan-progress {
+  width: 100%;
+
+  .dp-progress-bar {
+    width: 100%;
+    height: 7px;
+    background-color: colors.$dp-color-cement;
+    border-radius: 10px;
+    overflow: hidden;
+
+    .progress {
+      height: 100%;
+      width: 25%;
+      background-color: colors.$dp-color-green;
+      transition:
+        width 0.5s ease-in-out,
+        background-color 0.5s ease-in-out;
+    }
+
+    .progress.exceeded {
+      width: 100%;
+      background-color: colors.$dp-color-orange-carousel;
+    }
+  }
+
+  .plan-info {
+    display: flex;
+    justify-content: space-between;
+
+    .text-green {
+      color: colors.$dp-color-darkgreen;
+    }
+
+    .text-orange {
+      color: colors.$dp-color-orange-carousel;
+    }
+  }
+}

--- a/src/stories/Widget.Plan.Progress.js
+++ b/src/stories/Widget.Plan.Progress.js
@@ -1,0 +1,28 @@
+import { html } from "lit-html";
+
+/**
+ * Primary UI component for user interaction
+ */
+export const WidgetPlanProgress = ({ percentage }) => {
+  return html`
+    <div class="dp-widget-plan-progress">
+      <p>Plan: <strong>20.000 Impresiones</strong></p>
+      <div class="dp-progress-bar">
+        <div
+          id="progress"
+          class="progress ${percentage == 100 ? "exceeded" : ""}"
+          style="width:${percentage}%"
+        ></div>
+      </div>
+      <p class="plan-info">
+        <span>Consumidas: <strong>10.000 Impresiones</strong></span>
+        <span
+          >Disponibles:
+          <strong class="${percentage == 100 ? "text-orange" : "text-green"} "
+            >20.000 Impresiones</strong
+          ></span
+        >
+      </p>
+    </div>
+  `;
+};

--- a/src/stories/Widget.Plan.Progress.stories.js
+++ b/src/stories/Widget.Plan.Progress.stories.js
@@ -1,0 +1,21 @@
+import { WidgetPlanProgress } from "./Widget.Plan.Progress";
+
+export default {
+  title: "Components/Widget.Plan.Progress",
+  argTypes: {
+    percentage: {
+      description: "Percentaje to show in the progress bar",
+      control: { type: "number" },
+      defaultValue: 50,
+    },
+  },
+};
+
+const Template = (args) => {
+  return WidgetPlanProgress(args);
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  percentage: 50,
+};


### PR DESCRIPTION
By controlling the components width we can show the progress. On reaching 100% we should add some custom classes that change the colors.


![image](https://github.com/user-attachments/assets/3c45d8e7-e1a6-44d2-9cb2-5d85fa212818)

![image](https://github.com/user-attachments/assets/db961b0f-34e0-4860-b09d-0286172e51a5)

![image](https://github.com/user-attachments/assets/161764a2-752d-453c-85a7-dea723082461)
