### PR TITLE
Extend field item for onsite rules

### DIFF
--- a/src/assets/scss/modules/_forms.scss
+++ b/src/assets/scss/modules/_forms.scss
@@ -236,6 +236,11 @@
         font-style: italic;
       }
     }
+
+    .field-item-onsite-rules {
+      @extend .field-item;
+      width: 105%;
+    }
   }
 
   input[type="checkbox"] {


### PR DESCRIPTION
Utilizando la posibilidad de extension que provee sass, cree una nueva clase que abarca los estilos de field-item y le suma el width que necesito para los fields de las rules de los widgets.