### PR TITLE
[DOI-2326] Make KPIs responsive

### DIFF
--- a/src/assets/scss/modules/_charts.scss
+++ b/src/assets/scss/modules/_charts.scss
@@ -64,5 +64,15 @@
       stroke-width: 2px;
       stroke-dasharray: 3, 3;
     }
+
+    .dp-overlay {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      z-index: 3;
+    }
   }
 }

--- a/src/assets/scss/templates/_dashboard.scss
+++ b/src/assets/scss/templates/_dashboard.scss
@@ -389,6 +389,7 @@
       border: 1px solid #e7e5dc;
       border-radius: 3px;
       padding: 12px 24px 12px 12px;
+      height: 100%;
 
       &:hover {
         box-shadow: 0 5px 15px rgba(0, 0, 0, 0.15);

--- a/src/assets/scss/templates/_dashboard.scss
+++ b/src/assets/scss/templates/_dashboard.scss
@@ -378,14 +378,9 @@
     margin: 30px 0;
 
     ul {
-      display: flex;
-      align-items: center;
-      justify-content: start;
-    }
-
-    li {
-      margin-right: 24px;
-      min-width: 18.5%;
+      display: grid;
+      gap: 20px;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
     }
 
     .dp-kpi-card {


### PR DESCRIPTION
The KPI boxes will now automatically adjust to the container's width, with a maximum of six boxes displayed per row. Any boxes beyond that limit will wrap to a new line.

Furthermore, when the screen is resized, each box will maintain its minimum width. Instead of shrinking further, any boxes that no longer fit will move down to the row below.