### PR TITLE
Reduce padding hover card

### DIFF
--- a/src/assets/scss/modules/_widget-card.scss
+++ b/src/assets/scss/modules/_widget-card.scss
@@ -69,7 +69,7 @@
     right: 0;
     width: 100%;
     height: 100%;
-    padding: 24px 24px;
+    padding: 18px 18px;
     color: colors.$dp-color-white;
     opacity: 0;
     transition: opacity 0.5s ease-in-out;


### PR DESCRIPTION
I noticed that the hover card we currently use has excessive padding on all sides, so I reduced it by 6px to gain more space for possible future integrations. Here is the result:

<img width="543" height="223" alt="image" src="https://github.com/user-attachments/assets/dd3afc32-8905-4a43-b21b-08d1d4f7a39a" />