### PR TITLE
[DOW-129] Apply error color to phone assistance-wrap

### DIFF
--- a/src/assets/scss/modules/_inputs.scss
+++ b/src/assets/scss/modules/_inputs.scss
@@ -541,13 +541,11 @@
   }
 
   .labelcontrol
-    .iti--allow-dropdown
-    input[aria-invalid="true"]
+    .iti--allow-dropdown:has(input[aria-invalid="true"])
     + .assistance-wrap
     span,
   .labelcontrol
-    .iti--allow-dropdown
-    input[aria-invalid="true"]
+    .iti--allow-dropdown:has(input[aria-invalid="true"])
     + .assistance-wrap
     p,
   .labelcontrol


### PR DESCRIPTION
This fixes the color for the wrap assistance message when there is an error in the phone input.

BEFORE:
<img width="513" height="695" alt="image" src="https://github.com/user-attachments/assets/68f9b1a2-cd37-41e3-bb9f-16c076ff724b" />


AFTER:
<img width="510" height="674" alt="image" src="https://github.com/user-attachments/assets/9800df16-7fad-40a0-b98b-4c5edcfc19b9" />
