### PR TITLE
[DOI-2958] Kpis component

### DIFF
--- a/src/assets/scss/helpers/_colors.scss
+++ b/src/assets/scss/helpers/_colors.scss
@@ -55,6 +55,7 @@ $dp-color-orange-focus: #e58900;
 $dp-color-orange-carousel: #e79433;
 $dp-color-orange-carousel-back: rgba(250, 178, 33, 0.1);
 $dp-color-orange-carousel-border: rgba(250, 178, 33, 0.4);
+$dp-color-purple: #b58fc1;
 $dp-color-purple-carousel: #8c6698;
 $dp-color-purple-carousel-back: rgba(229, 207, 227, 0.2);
 $dp-color-purple-carousel-border: rgba(180, 143, 193, 0.5);
@@ -235,12 +236,24 @@ $dp-color-onsite-gray-border: #e7e5dc;
     background: $dp-color-brown;
   }
 
+  .dp-color-brown {
+    color: $dp-color-brown;
+  }
+
   .dp-brown--hover {
     background: $dp-color-brown--hover;
   }
 
   .dp-brown-brightness {
     background: $dp-color-brown-brightness;
+  }
+
+  .dp-purple {
+    background: $dp-color-purple;
+  }
+
+  .dp-color-purple {
+    color: $dp-color-purple;
   }
 
   .dp-color-orange-focus {

--- a/src/stories/KPIs.js
+++ b/src/stories/KPIs.js
@@ -1,4 +1,5 @@
 import { html } from "lit-html";
+import { ifDefined } from "lit-html/directives/if-defined.js";
 
 const defaultKpis = [
   {
@@ -80,12 +81,18 @@ export const KPIs = ({
                     class=${`dp-assisted-sales-icon dpicon ${icon} ${iconColorClassName}`}
                   ></span>
                   <div class="dp-assisted-sales-text">
-                    <h3 class=${textColorClassName} style=${textStyles}>
+                    <h3
+                      class=${ifDefined(textColorClassName || undefined)}
+                      style=${ifDefined(textStyles || undefined)}
+                    >
                       ${value}
                     </h3>
-                    <span class=${textColorClassName} style=${textStyles}
-                      >${label}</span
+                    <span
+                      class=${ifDefined(textColorClassName || undefined)}
+                      style=${ifDefined(textStyles || undefined)}
                     >
+                      ${label}
+                    </span>
                   </div>
                 </div>
               </li>

--- a/src/stories/KPIs.js
+++ b/src/stories/KPIs.js
@@ -1,0 +1,100 @@
+import { html } from "lit-html";
+
+const defaultKpis = [
+  {
+    icon: "iconapp-persons",
+    value: "0",
+    label: "Visitas únicas",
+  },
+  {
+    icon: "iconapp-web-development",
+    value: "2",
+    label: "Widgets activos",
+  },
+  {
+    icon: "iconapp-web-eye",
+    value: "238",
+    label: "Impresiones",
+  },
+  {
+    icon: "iconapp-finger-tap",
+    value: "21",
+    label: "Clics",
+  },
+  {
+    icon: "iconapp-click",
+    value: "0.09",
+    label: "CTR",
+  },
+];
+
+export const kpiColorOptions = {
+  default: "",
+  green: "dp-color-green",
+  grey: "dp-color-grey",
+  brown: "dp-color-brown",
+  purple: "dp-color-purple",
+};
+
+const getStyleValue = (value) => (value && value !== "default" ? value : "");
+
+const getColorClassName = (value) => kpiColorOptions[value] || "";
+
+const getTypographyStyles = ({ fontFamily, fontWeight, fontStyle }) =>
+  [
+    getStyleValue(fontFamily) ? `font-family: ${fontFamily}` : "",
+    getStyleValue(fontWeight) ? `font-weight: ${fontWeight}` : "",
+    getStyleValue(fontStyle) ? `font-style: ${fontStyle}` : "",
+  ]
+    .filter(Boolean)
+    .join("; ");
+
+/**
+ * KPI cards used by Popuphub dashboards.
+ */
+export const KPIs = ({
+  items = defaultKpis,
+  iconColor,
+  textColor,
+  fontFamily,
+  fontWeight,
+  fontStyle,
+}) => {
+  const textStyles = getTypographyStyles({
+    fontFamily,
+    fontWeight,
+    fontStyle,
+  });
+  const textColorClassName = getColorClassName(textColor);
+  const iconColorClassName = getColorClassName(iconColor);
+
+  return html`
+    <section class="dp-library">
+      <div class="dp-wrapper-as-kpi">
+        <ul>
+          ${items.map(
+            ({ icon, value, label }) => html`
+              <li>
+                <div class="dp-kpi-card dp-white">
+                  <span
+                    class=${`dp-assisted-sales-icon dpicon ${icon} ${iconColorClassName}`}
+                  ></span>
+                  <div class="dp-assisted-sales-text">
+                    <h3 class=${textColorClassName} style=${textStyles}>
+                      ${value}
+                    </h3>
+                    <span class=${textColorClassName} style=${textStyles}
+                      >${label}</span
+                    >
+                  </div>
+                </div>
+              </li>
+            `,
+          )}
+        </ul>
+      </div>
+    </section>
+  `;
+};
+
+export const defaultKpiItems = defaultKpis;

--- a/src/stories/KPIs.stories.js
+++ b/src/stories/KPIs.stories.js
@@ -1,0 +1,51 @@
+import { KPIs, defaultKpiItems, kpiColorOptions } from "./KPIs";
+
+const colorOptions = Object.keys(kpiColorOptions);
+
+export default {
+  title: "Components/KPIs",
+  argTypes: {
+    items: {
+      control: { type: "object" },
+      description:
+        "KPI cards to render. Each item supports icon, value and label.",
+    },
+    iconColor: {
+      control: { type: "select" },
+      description: "Icon color from the documented style guide palette.",
+      options: colorOptions,
+    },
+    textColor: {
+      control: { type: "select" },
+      description: "Text color from the documented style guide palette.",
+      options: colorOptions,
+    },
+    fontFamily: {
+      control: { type: "select" },
+      description: "Font family for KPI values and labels.",
+      options: ["default", "Arial", "Helvetica", "Roboto", "Georgia"],
+    },
+    fontWeight: {
+      control: { type: "select" },
+      description: "Font weight for KPI values and labels.",
+      options: ["default", "400", "500", "600", "700"],
+    },
+    fontStyle: {
+      control: { type: "select" },
+      description: "Font style for KPI values and labels.",
+      options: ["default", "italic"],
+    },
+  },
+};
+
+const Template = (args) => KPIs(args);
+
+export const Default = Template.bind({});
+Default.args = {
+  items: defaultKpiItems,
+  iconColor: "purple",
+  textColor: "default",
+  fontFamily: "default",
+  fontWeight: "default",
+  fontStyle: "default",
+};


### PR DESCRIPTION
Se agrega el componente KPIs a Storybook, tomando como referencia el KPI usado en doppler-popuphub-frontend y respetando su estructura visual y clases CSS.

- Se creó la nueva story Components/KPIs.
- Se replicó la estructura del KPI default usada en Popuphub.

Se agregaron controles en Storybook para personalizar:
- ícono
- color del ícono
- textos
- color de texto
- familia tipográfica
- peso de fuente
- estilo de fuente

<img width="1910" height="857" alt="image" src="https://github.com/user-attachments/assets/a1c7e70a-eb36-4337-905e-76e4b64ace39" />
