### PR TITLE
[DOI-2959] Allow custom icon in Pill component

### DIFF
--- a/src/assets/scss/modules/_pill.scss
+++ b/src/assets/scss/modules/_pill.scss
@@ -73,5 +73,15 @@ $pill-colors: (
         opacity: 0.8;
       }
     }
+
+    .pill-close-icon {
+      font-size: 16px;
+      line-height: 1;
+      color: inherit;
+    }
+
+    > .pill-close-icon {
+      margin-left: 4px;
+    }
   }
 }

--- a/src/stories/Pill.js
+++ b/src/stories/Pill.js
@@ -6,18 +6,22 @@ export const Pill = ({
   expandable = false,
   color = "green",
   icon = "icon-cancel-icon",
+  isButton = true,
 }) => {
   const iconClass = icon || "icon-cancel-icon";
+  const pillIcon = html`<i class=${`pill-close-icon ${iconClass}`}></i>`;
 
   return html`
     <div class="pill pill--${color} ${expandable ? "pill--expandable" : ""}">
       <span class="pill-text">${text}</span>
       ${removable
-        ? html`
-            <button class="pill-close" aria-label="Remove">
-              <i class=${iconClass}></i>
-            </button>
-          `
+        ? isButton
+          ? html`
+              <button class="pill-close" aria-label="Remove">
+                ${pillIcon}
+              </button>
+            `
+          : pillIcon
         : ""}
     </div>
   `;

--- a/src/stories/Pill.js
+++ b/src/stories/Pill.js
@@ -6,7 +6,7 @@ export const Pill = ({
   expandable = false,
   color = "green",
   icon = "icon-cancel-icon",
-  isButton = true,
+  isClickable = true,
 }) => {
   const iconClass = icon || "icon-cancel-icon";
   const pillIcon = html`<i class=${`pill-close-icon ${iconClass}`}></i>`;
@@ -15,7 +15,7 @@ export const Pill = ({
     <div class="pill pill--${color} ${expandable ? "pill--expandable" : ""}">
       <span class="pill-text">${text}</span>
       ${removable
-        ? isButton
+        ? isClickable
           ? html`
               <button class="pill-close" aria-label="Remove">
                 ${pillIcon}

--- a/src/stories/Pill.js
+++ b/src/stories/Pill.js
@@ -5,14 +5,17 @@ export const Pill = ({
   removable = true,
   expandable = false,
   color = "green",
+  icon = "icon-cancel-icon",
 }) => {
+  const iconClass = icon || "icon-cancel-icon";
+
   return html`
     <div class="pill pill--${color} ${expandable ? "pill--expandable" : ""}">
       <span class="pill-text">${text}</span>
       ${removable
         ? html`
             <button class="pill-close" aria-label="Remove">
-              <i class="icon-cancel-icon"></i>
+              <i class=${iconClass}></i>
             </button>
           `
         : ""}

--- a/src/stories/Pill.stories.js
+++ b/src/stories/Pill.stories.js
@@ -21,7 +21,8 @@ export default {
           "the pill becomes fixed. |\n| **expandable** | `boolean` | When enabled, " +
           "the pill **doesn’t limit its width** (it can exceed 212px) " +
           "and the text **is not truncated**. When disabled, the text is shortened with" +
-          " ellipsis to maintain a controlled size. |\n\n" +
+          " ellipsis to maintain a controlled size. |\n" +
+          "| **icon** | `string` | Defines the icon class used inside the close button. Defaults to `icon-cancel-icon`. |\n\n" +
           "---\n\n" +
           "### 🎨 Styles and Structure\n\n" +
           "Each pill has its own border and background color, defined through the SCSS " +
@@ -39,14 +40,14 @@ export default {
           '<div class="pill pill--green">\n' +
           '  <span class="pill-text">Septiembre 2025 - Septiembre 2025</span>\n' +
           '  <button class="pill-close" aria-label="Remove">\n' +
-          '    <i class="icon-cancel-icon"></i>\n' +
+          '    <i class="{icon}"></i>\n' +
           "  </button>\n" +
           "</div>\n" +
           "```\n\n" +
           "---\n\n" +
-          "### ❌ Close Icon (Inline SVG)\n\n" +
-          "The close icon is now rendered using an **inline SVG** through the `<i>` element.\n\n" +
-          "This allows the SVG to **inherit the color** from its parent pill, adapting automatically " +
+          "### ❌ Close Icon\n\n" +
+          "The close icon is rendered through the `<i>` element using the class received in `icon`.\n\n" +
+          "This allows the icon to **inherit the color** from its parent pill, adapting automatically " +
           "to the current color variant (e.g. `.pill--green`).\n\n" +
           "---\n\n" +
           "### 🧩 Grouping Multiple Pills\n\n" +
@@ -94,6 +95,11 @@ export default {
       defaultValue: true,
       description: "Show or hide the close button",
     },
+    icon: {
+      control: "text",
+      defaultValue: "icon-cancel-icon",
+      description: "Icon class displayed inside the close button",
+    },
     expandable: {
       control: "boolean",
       defaultValue: false,
@@ -116,6 +122,7 @@ const commonArgs = {
   removable: true,
   expandable: false,
   color: "green",
+  icon: "icon-cancel-icon",
 };
 
 export const Green = Template.bind({});

--- a/src/stories/Pill.stories.js
+++ b/src/stories/Pill.stories.js
@@ -22,7 +22,8 @@ export default {
           "the pill **doesn’t limit its width** (it can exceed 212px) " +
           "and the text **is not truncated**. When disabled, the text is shortened with" +
           " ellipsis to maintain a controlled size. |\n" +
-          "| **icon** | `string` | Defines the icon class used inside the close button. Defaults to `icon-cancel-icon`. |\n\n" +
+          "| **icon** | `string` | Defines the icon class used inside the close button. Defaults to `icon-cancel-icon`. |\n" +
+          "| **isButton** | `boolean` | Defines if the icon is rendered inside a button. Defaults to `true`. |\n\n" +
           "---\n\n" +
           "### 🎨 Styles and Structure\n\n" +
           "Each pill has its own border and background color, defined through the SCSS " +
@@ -40,13 +41,14 @@ export default {
           '<div class="pill pill--green">\n' +
           '  <span class="pill-text">Septiembre 2025 - Septiembre 2025</span>\n' +
           '  <button class="pill-close" aria-label="Remove">\n' +
-          '    <i class="{icon}"></i>\n' +
+          '    <i class="pill-close-icon {icon}"></i>\n' +
           "  </button>\n" +
           "</div>\n" +
           "```\n\n" +
           "---\n\n" +
           "### ❌ Close Icon\n\n" +
-          "The close icon is rendered through the `<i>` element using the class received in `icon`.\n\n" +
+          "The close icon is rendered through the `<i>` element using the class received in `icon`. " +
+          "When `isButton` is disabled, the `<button>` wrapper is not rendered.\n\n" +
           "This allows the icon to **inherit the color** from its parent pill, adapting automatically " +
           "to the current color variant (e.g. `.pill--green`).\n\n" +
           "---\n\n" +
@@ -100,6 +102,11 @@ export default {
       defaultValue: "icon-cancel-icon",
       description: "Icon class displayed inside the close button",
     },
+    isButton: {
+      control: "boolean",
+      defaultValue: true,
+      description: "Render the icon inside a button wrapper",
+    },
     expandable: {
       control: "boolean",
       defaultValue: false,
@@ -123,6 +130,7 @@ const commonArgs = {
   expandable: false,
   color: "green",
   icon: "icon-cancel-icon",
+  isButton: true,
 };
 
 export const Green = Template.bind({});

--- a/src/stories/Pill.stories.js
+++ b/src/stories/Pill.stories.js
@@ -22,8 +22,10 @@ export default {
           "the pill **doesn’t limit its width** (it can exceed 212px) " +
           "and the text **is not truncated**. When disabled, the text is shortened with" +
           " ellipsis to maintain a controlled size. |\n" +
-          "| **icon** | `string` | Defines the icon class used inside the close button. Defaults to `icon-cancel-icon`. |\n" +
-          "| **isButton** | `boolean` | Defines if the icon is rendered inside a button. Defaults to `true`. |\n\n" +
+          "| **icon** | `string` | Defines the icon class used inside the close button. " +
+          "Defaults to `icon-cancel-icon`. |\n" +
+          "| **isButton** | `boolean` | Defines if the icon is rendered inside a button. " +
+          "Defaults to `true`. |\n\n" +
           "---\n\n" +
           "### 🎨 Styles and Structure\n\n" +
           "Each pill has its own border and background color, defined through the SCSS " +

--- a/src/stories/Pill.stories.js
+++ b/src/stories/Pill.stories.js
@@ -24,7 +24,7 @@ export default {
           " ellipsis to maintain a controlled size. |\n" +
           "| **icon** | `string` | Defines the icon class used inside the close button. " +
           "Defaults to `icon-cancel-icon`. |\n" +
-          "| **isButton** | `boolean` | Defines if the icon is rendered inside a button. " +
+          "| **isClickable** | `boolean` | Defines if the icon is rendered inside a button. " +
           "Defaults to `true`. |\n\n" +
           "---\n\n" +
           "### 🎨 Styles and Structure\n\n" +
@@ -50,7 +50,7 @@ export default {
           "---\n\n" +
           "### ❌ Close Icon\n\n" +
           "The close icon is rendered through the `<i>` element using the class received in `icon`. " +
-          "When `isButton` is disabled, the `<button>` wrapper is not rendered.\n\n" +
+          "When `isClickable` is disabled, the `<button>` wrapper is not rendered.\n\n" +
           "This allows the icon to **inherit the color** from its parent pill, adapting automatically " +
           "to the current color variant (e.g. `.pill--green`).\n\n" +
           "---\n\n" +
@@ -104,7 +104,7 @@ export default {
       defaultValue: "icon-cancel-icon",
       description: "Icon class displayed inside the close button",
     },
-    isButton: {
+    isClickable: {
       control: "boolean",
       defaultValue: true,
       description: "Render the icon inside a button wrapper",
@@ -132,7 +132,7 @@ const commonArgs = {
   expandable: false,
   color: "green",
   icon: "icon-cancel-icon",
-  isButton: true,
+  isClickable: true,
 };
 
 export const Green = Template.bind({});


### PR DESCRIPTION
Se actualizó el componente Pill para permitir configurar el icono que se muestra junto al texto. Por defecto mantiene el comportamiento actual usando icon-cancel-icon dentro de un botón, pero ahora la clase del icono puede modificarse desde el control icon en Storybook y también se puede elegir si el icono se renderiza dentro de un <button> o como icono simple.

- Se agregó la prop icon al componente Pill.
- Se mantiene icon-cancel-icon como valor por defecto.
- Se agregó la prop isButton, con valor por defecto true, para conservar el render actual con `<button>`.
- Cuando isButton es false, el componente renderiza solo el icono sin el wrapper de botón.
- Se agregó un input de texto en Storybook para cambiar la clase del icono.
- Se agregó un control booleano en Storybook para alternar isButton.
- Se ajustó el SCSS para mantener compatibilidad con el markup existente y soportar el nuevo modo de icono simple.
- Se actualizó la documentación de la story para reflejar el nuevo comportamiento.