### PR TITLE
[DOI-2960] TutorialCard component

### DIFF
--- a/src/assets/scss/modules/_index.scss
+++ b/src/assets/scss/modules/_index.scss
@@ -27,3 +27,4 @@
 @use "modules/widget-bubble";
 @use "modules/datePicker";
 @use "modules/pill";
+@use "modules/tutorial-card";

--- a/src/assets/scss/modules/_pill.scss
+++ b/src/assets/scss/modules/_pill.scss
@@ -3,9 +3,13 @@
 @use "core/typography";
 
 $pill-colors: (
-  green: (
+  "green": (
     border: colors.$dp-color-green,
     bg: colors.$dp-color-green-brightness,
+  ),
+  "blue": (
+    border: colors.$dp-color-blue-widget,
+    bg: #2a75db33,
   ),
 );
 

--- a/src/assets/scss/modules/_tutorial-card.scss
+++ b/src/assets/scss/modules/_tutorial-card.scss
@@ -1,0 +1,119 @@
+@use "core/settings";
+@use "core/variables";
+@use "helpers/colors";
+
+.dp-library {
+  .dp-tutorial-card {
+    width: min(100%, 490px);
+    padding: 40px;
+    border: 1px solid colors.$dp-color-separator;
+    border-radius: variables.$dp-border-radius;
+    background-color: colors.$dp-color-white;
+    box-sizing: border-box;
+    font-family: settings.$dp-font-family;
+  }
+
+  .dp-tutorial-card__media {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 411 / 239;
+    overflow: hidden;
+    background-color: #2a75db33;
+  }
+
+  .dp-tutorial-card__media::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-color: rgba(0, 0, 0, 0.28);
+  }
+
+  .dp-tutorial-card__media--without-overlay::after {
+    content: none;
+  }
+
+  .dp-tutorial-card__image {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .dp-tutorial-card__play {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    z-index: 1;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background-color: colors.$dp-color-white;
+    transform: translate(-50%, -50%);
+  }
+
+  .dp-tutorial-card__play::before {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 53%;
+    border-top: 10px solid transparent;
+    border-bottom: 10px solid transparent;
+    border-left: 14px solid colors.$dp-color-darkgrey;
+    transform: translate(-50%, -50%);
+  }
+
+  .dp-tutorial-card__body {
+    margin-top: variables.$dp-spaces--lv4;
+  }
+
+  .dp-tutorial-card .pill {
+    max-width: 100%;
+    padding: 2px variables.$dp-spaces--lv2;
+    border: 0;
+    font-size: variables.$dp-sizing--lvl5;
+    font-weight: settings.$dp-font-weight-bold;
+    line-height: variables.$dp-spaces--lv5;
+  }
+
+  .dp-tutorial-card .pill-text {
+    max-width: 100%;
+  }
+
+  .dp-tutorial-card__title {
+    margin: variables.$dp-spaces--lv1 0 0;
+    padding-bottom: 0;
+    color: colors.$dp-color-darkgrey;
+    font-size: 30px;
+    font-weight: settings.$dp-font-weight-bold;
+    line-height: variables.$dp-spaces--lv6;
+  }
+
+  .dp-tutorial-card__author {
+    margin-top: variables.$dp-spaces--lv1;
+    color: colors.$dp-color-lightgrey;
+    font-size: variables.$dp-sizing--lvl6;
+    font-weight: settings.$dp-font-weight-bold;
+    line-height: variables.$dp-spaces--lv5;
+  }
+
+  @media (max-width: 480px) {
+    .dp-tutorial-card {
+      padding: variables.$dp-spaces--lv4;
+    }
+
+    .dp-tutorial-card .pill {
+      font-size: variables.$dp-sizing--lvl4;
+      line-height: variables.$dp-spaces--lv4;
+    }
+
+    .dp-tutorial-card__title {
+      font-size: variables.$dp-sizing--lvl6;
+      line-height: variables.$dp-spaces--lv5;
+    }
+
+    .dp-tutorial-card__author {
+      font-size: variables.$dp-sizing--lvl4;
+      line-height: variables.$dp-spaces--lv4;
+    }
+  }
+}

--- a/src/stories/Pill.stories.js
+++ b/src/stories/Pill.stories.js
@@ -117,7 +117,7 @@ export default {
     },
     color: {
       control: { type: "select" },
-      options: ["green"],
+      options: ["green", "blue"],
       defaultValue: "green",
       description: "Defines the border and background color of the pill.",
     },
@@ -137,6 +137,12 @@ const commonArgs = {
 
 export const Green = Template.bind({});
 Green.args = { ...commonArgs };
+
+export const Blue = Template.bind({});
+Blue.args = {
+  ...commonArgs,
+  color: "blue",
+};
 
 export const WithoutClose = Template.bind({});
 WithoutClose.args = {

--- a/src/stories/Pill.stories.js
+++ b/src/stories/Pill.stories.js
@@ -135,14 +135,8 @@ const commonArgs = {
   isClickable: true,
 };
 
-export const Green = Template.bind({});
-Green.args = { ...commonArgs };
-
-export const Blue = Template.bind({});
-Blue.args = {
-  ...commonArgs,
-  color: "blue",
-};
+export const Default = Template.bind({});
+Default.args = { ...commonArgs };
 
 export const WithoutClose = Template.bind({});
 WithoutClose.args = {

--- a/src/stories/TutorialCard.js
+++ b/src/stories/TutorialCard.js
@@ -1,0 +1,44 @@
+import { html } from "lit-html";
+
+import tutorialCardImage from "../assets/img/sample01.jpg";
+import { Pill } from "./Pill";
+
+export const TutorialCard = ({
+  pillText = "Email Automation",
+  title = "Cómo crear un Automation de Pago Confirmado",
+  author = "Virginia Garay",
+  showPlayIcon = true,
+}) => {
+  return html`
+    <article class="dp-tutorial-card">
+      <div
+        class=${`dp-tutorial-card__media ${
+          showPlayIcon ? "" : "dp-tutorial-card__media--without-overlay"
+        }`}
+      >
+        <img
+          class="dp-tutorial-card__image"
+          src=${tutorialCardImage}
+          alt=${title}
+        />
+        ${showPlayIcon
+          ? html`<span
+              class="dp-tutorial-card__play"
+              aria-hidden="true"
+            ></span>`
+          : ""}
+      </div>
+
+      <div class="dp-tutorial-card__body">
+        ${Pill({
+          text: pillText,
+          removable: false,
+          expandable: true,
+          color: "blue",
+        })}
+        <h3 class="dp-tutorial-card__title">${title}</h3>
+        <p class="dp-tutorial-card__author">Por ${author}</p>
+      </div>
+    </article>
+  `;
+};

--- a/src/stories/TutorialCard.stories.js
+++ b/src/stories/TutorialCard.stories.js
@@ -2,22 +2,80 @@ import { TutorialCard } from "./TutorialCard";
 
 export default {
   title: "Components/TutorialCard",
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "**TutorialCard Component**\n\n" +
+          "The `TutorialCard` component is used to highlight a tutorial or educational resource " +
+          "inside a card layout with image, category pill, title, and author.\n\n" +
+          "---\n\n" +
+          "### Main Properties\n\n" +
+          "| Property | Type | Description |\n" +
+          "|----------|------|-------------|\n" +
+          "| **pillText** | `string` | Text displayed inside the top pill. " +
+          "It is rendered using the shared `Pill` component with the blue variant. |\n" +
+          "| **title** | `string` | Main tutorial title shown below the pill. |\n" +
+          "| **author** | `string` | Author name displayed with the `Por ...` prefix. |\n" +
+          "| **showPlayIcon** | `boolean` | Shows or hides the centered play icon. " +
+          "When disabled, the dark overlay on the image is also removed. |\n\n" +
+          "---\n\n" +
+          "### Styles and Structure\n\n" +
+          "The component uses a fixed visual structure with a hardcoded image asset " +
+          "and reusable style-guide primitives:\n\n" +
+          "- `Pill` for the category label\n" +
+          "- custom card styles for spacing, media, and typography\n" +
+          "- a CSS-built play icon rendered only when `showPlayIcon = true`\n\n" +
+          "The generated HTML structure looks like this:\n\n" +
+          "```html\n" +
+          '<article class="dp-tutorial-card">\n' +
+          '  <div class="dp-tutorial-card__media">\n' +
+          '    <img class="dp-tutorial-card__image" src="..." alt="Tutorial title" />\n' +
+          '    <span class="dp-tutorial-card__play" aria-hidden="true"></span>\n' +
+          "  </div>\n" +
+          '  <div class="dp-tutorial-card__body">\n' +
+          '    <div class="pill pill--blue">...</div>\n' +
+          '    <h3 class="dp-tutorial-card__title">Tutorial title</h3>\n' +
+          '    <p class="dp-tutorial-card__author">Por Author Name</p>\n' +
+          "  </div>\n" +
+          "</article>\n" +
+          "```\n\n" +
+          "---\n\n" +
+          "### Play Icon and Overlay\n\n" +
+          "The play icon is not an SVG or image asset. " +
+          "It is built with CSS using a circular element and a triangle created with borders.\n\n" +
+          "When `showPlayIcon` is disabled, the component also adds the modifier class " +
+          "`.dp-tutorial-card__media--without-overlay` to remove the dark overlay from the image.\n\n" +
+          "---\n\n" +
+          "### Visual and Behavioral Summary\n\n" +
+          "- Uses a hardcoded image asset, ready to be replaced later if needed.\n" +
+          "- Reuses the shared `Pill` component with the `blue` color variant.\n" +
+          "- Keeps the API intentionally small: only texts and play visibility " +
+          "are configurable.\n" +
+          "- Includes responsive adjustments for smaller screens.\n",
+      },
+    },
+  },
   argTypes: {
     pillText: {
       control: "text",
       description: "Text inside the pill",
+      defaultValue: "Email Automation",
     },
     title: {
       control: "text",
       description: "Tutorial title",
+      defaultValue: "Cómo crear un Automation de Pago Confirmado",
     },
     author: {
       control: "text",
       description: "Tutorial author",
+      defaultValue: "Virginia Garay",
     },
     showPlayIcon: {
       control: "boolean",
       description: "Show or hide the play icon over the image",
+      defaultValue: true,
     },
   },
 };

--- a/src/stories/TutorialCard.stories.js
+++ b/src/stories/TutorialCard.stories.js
@@ -1,0 +1,33 @@
+import { TutorialCard } from "./TutorialCard";
+
+export default {
+  title: "Components/TutorialCard",
+  argTypes: {
+    pillText: {
+      control: "text",
+      description: "Text inside the pill",
+    },
+    title: {
+      control: "text",
+      description: "Tutorial title",
+    },
+    author: {
+      control: "text",
+      description: "Tutorial author",
+    },
+    showPlayIcon: {
+      control: "boolean",
+      description: "Show or hide the play icon over the image",
+    },
+  },
+};
+
+const Template = (args) => TutorialCard(args);
+
+export const Default = Template.bind({});
+Default.args = {
+  pillText: "Email Automation",
+  title: "Cómo crear un Automation de Pago Confirmado",
+  author: "Virginia Garay",
+  showPlayIcon: true,
+};


### PR DESCRIPTION
Se agrega el nuevo componente `TutorialCard` al style guide.

Este componente está pensado para mostrar contenido de tutoriales con una estructura fija de tarjeta que incluye:
- área de imagen
- pill de categoría
- título
- autor
- overlay opcional con ícono de play

## Cambios

- Se agregó el componente `TutorialCard` y su story en Storybook
- Se agregaron estilos SCSS específicos para la tarjeta de tutorial
- Se reutilizó el componente existente `Pill` dentro de la tarjeta
- Se agregó una nueva variante `blue` a `Pill`
- Se incorporó la propiedad `showPlayIcon` para mostrar u ocultar el ícono de play
- Cuando `showPlayIcon` está desactivado, también se remueve el overlay oscuro de la imagen
- Se agregó documentación de Storybook para `TutorialCard`
- Se simplificaron las stories de `Pill` para usar una única story `Default` en lugar de separar por color

## Notas

- La imagen del tutorial está hardcodeada por ahora
- Solo son configurables los textos y la visibilidad del ícono de play

Se dijo de no hacer lo del boton de "play", pero lo cierto es que Codex lo resolvio rapidismo y es un adorno que no veo mal considerando que pueda llegar a reutilizarse en un futuro. Si lo ven innecesario lo quito.

<img width="1913" height="857" alt="image" src="https://github.com/user-attachments/assets/578334af-712b-43a2-84de-71ddab8b3133" />